### PR TITLE
Add ability for `instructlab-knowledge` notebook to take multiple source and qna files

### DIFF
--- a/notebooks/instructlab-knowledge/instructlab-knowledge.ipynb
+++ b/notebooks/instructlab-knowledge/instructlab-knowledge.ipynb
@@ -279,9 +279,9 @@
    "id": "42c4160f-7508-4c72-b28d-b56aa4975b26",
    "metadata": {},
    "source": [
-    "### Save the chunks to a text file for each chunk\n",
+    "### Save all chunks to a JSON file\n",
     "\n",
-    "Each chunk is saved to an individual text file in the format: `{docling-json-file-name}-{chunk #}.txt`. Having chunking in this format is important as an input to create-sdg-seed-data notebook."
+    "All chunks are saved to a JSON file called chunks.jsonl in CHUNKING_OUTPUT_DIR. This file is one of the inputs father below when we create the seed dataset for SDG."
    ]
   },
   {
@@ -291,10 +291,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for i, chunk in enumerate(all_chunks):\n",
-    "    chunk_path = CHUNKING_OUTPUT_DIR / f\"{chunk['file']}-{i}.txt\"\n",
-    "    with open(chunk_path, \"w\") as file:\n",
-    "        file.write(chunk[\"chunk\"])"
+    "chunks_file_path = CHUNKING_OUTPUT_DIR / \"chunks.jsonl\"\n",
+    "with open(chunks_file_path, \"w\", encoding=\"utf-8\") as file:\n",
+    "    for chunk in all_chunks:\n",
+    "        json.dump(chunk, file)\n",
+    "        file.write(\"\\n\")"
    ]
   },
   {
@@ -634,8 +635,8 @@
     "\n",
     "shutil.copy(qna_output_path, SEED_EXAMPLE_INPUT_DIR)\n",
     "\n",
-    "seed_data = get_seed_dataset(SEED_EXAMPLE_INPUT_DIR)\n",
-    "output_path = f'{SEED_EXAMPLE_OUTPUT_DIR}/seed_data.jsonl'\n",
+    "seed_data = get_seed_dataset(CHUNKING_OUTPUT_DIR, SEED_EXAMPLE_INPUT_DIR)\n",
+    "output_path = f'{SDG_OUTPUT_DIR}/seed_data.jsonl'\n",
     "seed_data.to_json(output_path, orient='records', lines=True)\n",
     "\n",
     "print(f\"Generated {seed_data.data.num_rows} rows\")\n",
@@ -673,15 +674,15 @@
     "2. Split the extracted text into chunks\n",
     "3. Generated QA pairs for a subset of those chunks\n",
     "4. Created a `qna.yaml` available for inspection and revision\n",
-    "5. Combined the chunks and `qna.yaml` to create a `seed.jsonl` for use with SDG\n",
+    "5. Combined the chunks and `qna.yaml` to create a `seed_data.jsonl` for use with SDG\n",
     "\n",
-    "The next step is to use the resulting `seed.jsonl` for SDG, such as illustrated in [this notebook](https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub/blob/main/examples/instructlab/knowledge/knowledge_generation_and_mixing.ipynb)."
+    "The next step is to use the resulting `seed_data.jsonl` for SDG, such as illustrated in [this notebook](https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub/blob/main/examples/instructlab/knowledge/knowledge_generation_and_mixing.ipynb)."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -695,7 +696,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.12"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/instructlab-knowledge/instructlab-knowledge.ipynb
+++ b/notebooks/instructlab-knowledge/instructlab-knowledge.ipynb
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "0acd026f-65bd-4393-bb40-f8aa8bd6828b",
    "metadata": {},
    "outputs": [],
@@ -67,20 +67,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "26501e2f-7215-441f-9efa-075f87024893",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Files to convert:\n",
-      "[PosixPath('workspaces/default/source_documents/nfl/2022-nfl-rulebook-final.pdf')]\n",
-      "[PosixPath('workspaces/default/source_documents/finance/BofA_InterestChecking_en_ADA.pdf'), PosixPath('workspaces/default/source_documents/finance/Advantag Savings.pdf')]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# struct would have document outline, domain, and path to pdf's for each contribution\n",
     "\n",
@@ -130,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "b91d4b2e-19cd-46e7-a912-ba9b2904c7cd",
    "metadata": {},
    "outputs": [],
@@ -152,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "157c5e02-edd1-44f6-b20f-f6b4bda1aae7",
    "metadata": {},
    "outputs": [],
@@ -182,20 +172,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "a200039c-b8b2-4087-88ba-7bfb0e393cc9",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Path of JSON output is: /Users/amaredia/dev/examples/notebooks/instructlab-knowledge/workspaces/default/conversion/nfl/2022-nfl-rulebook-final.json\n",
-      "Path of JSON output is: /Users/amaredia/dev/examples/notebooks/instructlab-knowledge/workspaces/default/conversion/finance/BofA_InterestChecking_en_ADA.json\n",
-      "Path of JSON output is: /Users/amaredia/dev/examples/notebooks/instructlab-knowledge/workspaces/default/conversion/finance/Advantag Savings.json\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import json\n",
     "\n",
@@ -243,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "50df9d91-add4-46a1-a69d-0f7f9f69542e",
    "metadata": {},
    "outputs": [],
@@ -280,30 +260,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "db983c05-4aa6-4261-9283-2adab69bfbd3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Token indices sequence length is longer than the specified maximum sequence length for this model (583 > 512). Running this sequence through the model will result in indexing errors\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Extracted 1798 chunks from 2022-nfl-rulebook-final\n",
-      "Extracted 10 chunks from BofA_InterestChecking_en_ADA\n",
-      "Extracted 5 chunks from Advantag Savings\n",
-      "Extracted 1798 chunks from 2022-nfl-rulebook-final\n",
-      "Extracted 10 chunks from BofA_InterestChecking_en_ADA\n",
-      "Extracted 5 chunks from Advantag Savings\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for contribution in contributions:\n",
     "    contribution[\"all_chunks\"] = []\n",
@@ -337,19 +297,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "4fdf34c7-9829-43d2-bf9f-7d1d55bb6a4c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2022 OFFICIAL PLAYING RULES OF THE NATIONAL FOOTBALL LEAGUE\n",
-      "Roger Goodell, Commissioner\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(contributions[0][\"all_chunks\"][0][\"chunk\"])"
    ]
@@ -366,19 +317,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "6e70d576-a2bc-4274-b660-1cbe051968b1",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Path of chunks JSON is: /Users/amaredia/dev/examples/notebooks/instructlab-knowledge/workspaces/default/chunking/nfl/chunks.jsonl\n",
-      "Path of chunks JSON is: /Users/amaredia/dev/examples/notebooks/instructlab-knowledge/workspaces/default/chunking/finance/chunks.jsonl\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for contribution in contributions:\n",
     "    chunks_file_path = CHUNKING_OUTPUT_DIR / contribution[\"prefix\"] / \"chunks.jsonl\"\n",
@@ -399,21 +341,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "86c48e52-cda7-48ac-84dc-0b844aed5f98",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
-      "To disable this warning, you can either:\n",
-      "\t- Avoid using `tokenizers` before the fork if possible\n",
-      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!pip install -qq docling-sdg\n",
     "\n",
@@ -423,29 +354,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "2a165c38-843b-4c89-a8ad-6195b998e284",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Chunking and filtering document 2022-nfl-rulebook-final\n",
-      "Created dataset 2022-nfl-rulebook-final with 720 QA chunks\n",
-      "Chunking and filtering document BofA_InterestChecking_en_ADA\n",
-      "Created dataset BofA_InterestChecking_en_ADA with 8 QA chunks\n",
-      "Chunking and filtering document Advantag Savings\n",
-      "Created dataset Advantag Savings with 5 QA chunks\n",
-      "Chunking and filtering document 2022-nfl-rulebook-final\n",
-      "Created dataset 2022-nfl-rulebook-final with 720 QA chunks\n",
-      "Chunking and filtering document BofA_InterestChecking_en_ADA\n",
-      "Created dataset BofA_InterestChecking_en_ADA with 8 QA chunks\n",
-      "Chunking and filtering document Advantag Savings\n",
-      "Created dataset Advantag Savings with 5 QA chunks\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from docling_sdg.qa.utils import get_qa_chunks\n",
     "\n",
@@ -481,7 +393,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "874d4de8",
    "metadata": {
     "tags": [
@@ -497,7 +409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "id": "b702267e-f550-4bc2-bce4-c0fcecbbd292",
    "metadata": {},
    "outputs": [],
@@ -523,7 +435,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "f1197d4e-8354-45e3-9ec9-85c78ba36548",
    "metadata": {},
    "outputs": [],
@@ -541,197 +453,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "id": "e57edff5-9a13-47fb-9248-9140ae5baaca",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "processing chunks that looks like:\n",
-      "This edition of the Official Playing Rules of the  National Football League  contains all current rules governing the playing of professional football that are in effect for the 2022 NFL season. Member clubs of the League may amend the rules from time to time, pursuant to the applicable voting procedures of the NFL Constitution and Bylaws.\n",
-      "Any intra-League dispute or call for interpretation in connection with these rules will be decided by the Commissioner of the League, whose ruling will be final.\n",
-      "Because inter-conference games are played throughout the preseason, regular season, and postseason in  the  NFL, all  rules contained in  this  book apply uniformly to both the American and National Football Conferences.\n",
-      "Where the word 'illegal' appears in this rule book, it is an institutional term of art pertaining strictly to actions that violate NFL playing rules. It is not meant to connote illegality under any public law or the rules or regulations of any other organization.\n",
-      "The word 'flagrant,' when used here to describe an action by a player, is meant to indicate that the degree of a violation of the rules-usually a personal foul or  unnecessary roughness-is extremely objectionable, conspicuous, unnecessary, avoidable, or gratuitous. 'Flagrant' in these rules does not necessarily imply malice on the part of the fouling player or an intention to injure an opponent.\n",
-      "Copyright © 2022 by the National Football League. All rights reserved. Printed in the United States of America.\n",
-      "Bottom of the yard line numbers must be 12 yards from the sideline.\n",
-      "Selected 2 contexts\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "  0%|                                                                                                                                                                                                                                                             | 0/2 [00:00<?, ?it/s]PromptTypes.ANSWER prompt not available for types ['reasoning']\n",
-      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:06<00:00,  3.35s/it]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2022-nfl-rulebook-final: Status.SUCCESS\n",
-      "processing chunks that looks like:\n",
-      "Opening Deposit\n",
-      "$100 or more\n",
-      "Interest Rate\n",
-      "This account earns interest at a variable rate. You can find current rate information at bankofamerica.com, by calling the number on your account statement or visiting a financial center.\n",
-      "Monthly\n",
-      "Maintenance\n",
-      "Fee\n",
-      "$25.00 each month. You can avoid the Monthly Maintenance Fee when you meet ONE of the following requirements during each statement cycle:\n",
-      "• Maintain a minimum daily balance of $20,000 or more in your account OR\n",
-      "• Be a member of the Preferred Rewards program. Learn more at bankofamerica.com/preferred-rewards.\n",
-      "ATM fees\n",
-      "Bank of America ATMs\n",
-      "No ATM fee\n",
-      "For deposits, withdrawals, transfers or balance inquiries\n",
-      "Non-Bank of America ATMs\n",
-      "$2.50\n",
-      "In the U.S., plus any fee charged by the ATM's operator\n",
-      "$5.00\n",
-      "Outside the U.S., plus any fee charged by the ATM's operator\n",
-      "Selected 2 contexts\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:07<00:00,  3.98s/it]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BofA_InterestChecking_en_ADA: Status.SUCCESS\n",
-      "processing chunks that looks like:\n",
-      "FDIC\n",
-      "Coverage\n",
-      "This account is insured by the Federal Deposit Insurance Corporation (FDIC) and is backed by the U.S. government. The standard insurance amount is $250,000 per depositor, per insured bank, for each account ownership category.\n",
-      "Monthly Maintenance Fee\n",
-      "$8.00\n",
-      "each month\n",
-      "(We'll waive this fee for the first 6 months.)\n",
-      "You can avoid the Monthly Maintenance Fee when you meet ONE of the following requirements during each statement cycle:\n",
-      "· Maintain a minimum daily balance of $500 or more in your account, OR\n",
-      "· Ask us to link your account to your Bank of America Advantage Relationship Banking ® , Bank of America Advantage  with Tiered Interest Checking or Bank of America Advantage ® ® Regular Checking account (first 4 savings accounts), OR\n",
-      "· An owner of this account is under the age of 25 (fiduciary accounts don't qualify), OR\n",
-      "· Be a member of the Preferred Rewards program. Learn more at bankofamerica.com/preferred-rewards, or visit your local financial center.\n",
-      "Selected 2 contexts\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:06<00:00,  3.29s/it]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Advantag Savings: Status.SUCCESS\n",
-      "processing chunks that looks like:\n",
-      "This edition of the Official Playing Rules of the  National Football League  contains all current rules governing the playing of professional football that are in effect for the 2022 NFL season. Member clubs of the League may amend the rules from time to time, pursuant to the applicable voting procedures of the NFL Constitution and Bylaws.\n",
-      "Any intra-League dispute or call for interpretation in connection with these rules will be decided by the Commissioner of the League, whose ruling will be final.\n",
-      "Because inter-conference games are played throughout the preseason, regular season, and postseason in  the  NFL, all  rules contained in  this  book apply uniformly to both the American and National Football Conferences.\n",
-      "Where the word 'illegal' appears in this rule book, it is an institutional term of art pertaining strictly to actions that violate NFL playing rules. It is not meant to connote illegality under any public law or the rules or regulations of any other organization.\n",
-      "The word 'flagrant,' when used here to describe an action by a player, is meant to indicate that the degree of a violation of the rules-usually a personal foul or  unnecessary roughness-is extremely objectionable, conspicuous, unnecessary, avoidable, or gratuitous. 'Flagrant' in these rules does not necessarily imply malice on the part of the fouling player or an intention to injure an opponent.\n",
-      "Copyright © 2022 by the National Football League. All rights reserved. Printed in the United States of America.\n",
-      "Bottom of the yard line numbers must be 12 yards from the sideline.\n",
-      "Selected 2 contexts\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:06<00:00,  3.12s/it]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2022-nfl-rulebook-final: Status.SUCCESS\n",
-      "processing chunks that looks like:\n",
-      "Opening Deposit\n",
-      "$100 or more\n",
-      "Interest Rate\n",
-      "This account earns interest at a variable rate. You can find current rate information at bankofamerica.com, by calling the number on your account statement or visiting a financial center.\n",
-      "Monthly\n",
-      "Maintenance\n",
-      "Fee\n",
-      "$25.00 each month. You can avoid the Monthly Maintenance Fee when you meet ONE of the following requirements during each statement cycle:\n",
-      "• Maintain a minimum daily balance of $20,000 or more in your account OR\n",
-      "• Be a member of the Preferred Rewards program. Learn more at bankofamerica.com/preferred-rewards.\n",
-      "ATM fees\n",
-      "Bank of America ATMs\n",
-      "No ATM fee\n",
-      "For deposits, withdrawals, transfers or balance inquiries\n",
-      "Non-Bank of America ATMs\n",
-      "$2.50\n",
-      "In the U.S., plus any fee charged by the ATM's operator\n",
-      "$5.00\n",
-      "Outside the U.S., plus any fee charged by the ATM's operator\n",
-      "Selected 2 contexts\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:08<00:00,  4.05s/it]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BofA_InterestChecking_en_ADA: Status.SUCCESS\n",
-      "processing chunks that looks like:\n",
-      "FDIC\n",
-      "Coverage\n",
-      "This account is insured by the Federal Deposit Insurance Corporation (FDIC) and is backed by the U.S. government. The standard insurance amount is $250,000 per depositor, per insured bank, for each account ownership category.\n",
-      "Monthly Maintenance Fee\n",
-      "$8.00\n",
-      "each month\n",
-      "(We'll waive this fee for the first 6 months.)\n",
-      "You can avoid the Monthly Maintenance Fee when you meet ONE of the following requirements during each statement cycle:\n",
-      "· Maintain a minimum daily balance of $500 or more in your account, OR\n",
-      "· Ask us to link your account to your Bank of America Advantage Relationship Banking ® , Bank of America Advantage  with Tiered Interest Checking or Bank of America Advantage ® ® Regular Checking account (first 4 savings accounts), OR\n",
-      "· An owner of this account is under the age of 25 (fiduciary accounts don't qualify), OR\n",
-      "· Be a member of the Preferred Rewards program. Learn more at bankofamerica.com/preferred-rewards, or visit your local financial center.\n",
-      "Selected 2 contexts\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:06<00:00,  3.01s/it]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Advantag Savings: Status.SUCCESS\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import random #TODO: replace random sampling with subset selection\n",
     "\n",
@@ -761,21 +486,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "id": "9df2c533-30d7-4c30-9907-7c5655fd2246",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Generated QA pairs for 6 contexts\n",
-      "[{'question': 'What happens to the injured player at the conclusion of an injury timeout prior to the two-minute warning?', 'answer': 'The injured player must leave the game for the completion of one down. However, they will be permitted to remain in the game if either team calls a charged team timeout, the injury is the result of a foul by an opponent, or the period ends or the two-minute warning occurs before the next snap.'}, {'question': 'What are the conditions under which an injured player can remain in the game during an injury timeout prior to the two-minute warning?', 'answer': 'The injured player can remain in the game if either team calls a charged team timeout, the injury is the result of a foul by an opponent, or the period ends or the two-minute warning occurs before the next snap.'}]\n",
-      "Generated QA pairs for 6 contexts\n",
-      "[{'question': \"How many players were initially on each side of Team A's kicker before the ball was blown off the tee?\", 'answer': \"There were five players on each side of Team A's kicker before the ball was blown off the tee.\"}, {'question': \"What is the ruling for Team A's formation after the ball was blown off the tee and A1 came in as the holder?\", 'answer': 'The ruling is that it is an illegal formation. Team A must have two players outside the yard-line numbers and two players between the inbounds line and the yard-line numbers, other than the holder.'}, {'question': 'Based on the information provided, why was the kick through the end zone considered illegal?', 'answer': 'The kick through the end zone was considered illegal because Team A had an illegal formation at the time of the kick.'}]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import json\n",
     "import yaml\n",
@@ -809,19 +523,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "id": "d7f26460-737f-4940-b58a-ef6caea313d3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "qna.yaml saved to: workspaces/default/authoring/nfl/qna.yaml\n",
-      "qna.yaml saved to: workspaces/default/authoring/finance/qna.yaml\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# The following creates a data structure for outputting in the expected format for qna.yaml\n",
     "# TODO: extract into utils library\n",
@@ -878,336 +583,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "id": "1293d445-b826-4b92-ad20-9b121ac60e20",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "========== qna.yaml at workspaces/default/authoring/nfl/qna.yaml ==========\n",
-      "seed_examples:\n",
-      "  - context: |-\n",
-      "      Note: If  an  attempt  is  made  to  call  a  timeout  in  such  situations,  the  officials  shall  not  grant  a  timeout;  instead,  play  will continue, and a penalty will be called, with customary enforcement. If a timeout is inadvertently granted and charged, the penalty shall also be enforced. See 12-3-1-w.\n",
-      "      ARTICLE 2.  INJURY TIMEOUTS. If an official determines a player to be injured, or if attendants from the bench come on the field to assist an injured player, an injury timeout will be called by the Referee. If the ATC Spotter identifies a player for medical attention, the rules pertaining to Injury Timeouts in Article 3 and Article 4 (c) apply.\n",
-      "      ARTICLE 3.  INJURY TIMEOUTS PRIOR TO TWO-MINUTE WARNING OF EITHER HALF. When an injury timeout is called, the injured player must leave the game for the completion of one down. The player will be permitted to remain in the game if:\n",
-      "      (a) either team calls a charged team timeout;\n",
-      "      (b) the injury is the result of a foul by an opponent; or\n",
-      "      (c) the period ends or the two-minute warning occurs before the next snap.\n",
-      "      At the conclusion of an injury timeout, the game clock will start as if the injury timeout had not occurred. If either team takes, or is charged with, a timeout, the clock will start on the snap.\n",
-      "      ARTICLE 4.  INJURY TIMEOUTS AFTER TWO-MINUTE WARNING OF EITHER HALF. After the two-minute  warning  of  a half, the following shall apply:\n",
-      "    questions_and_answers:\n",
-      "      - question: |-\n",
-      "          What happens to the injured player at the conclusion of an injury timeout prior\n",
-      "          to the two-minute warning?\n",
-      "        answer: |-\n",
-      "          The injured player must leave the game for the completion of one down. However,\n",
-      "          they will be permitted to remain in the game if either team calls a charged team\n",
-      "          timeout, the injury is the result of a foul by an opponent, or the period ends\n",
-      "          or the two-minute warning occurs before the next snap.\n",
-      "      - question: |-\n",
-      "          What are the conditions under which an injured player can remain in the game\n",
-      "          during an injury timeout prior to the two-minute warning?\n",
-      "        answer: |-\n",
-      "          The injured player can remain in the game if either team calls a charged team\n",
-      "          timeout, the injury is the result of a foul by an opponent, or the period ends\n",
-      "          or the two-minute warning occurs before the next snap.\n",
-      "  - context: |-\n",
-      "      Second-and-10 on B35. With 12:00 remaining in the fourth quarter, QBA1 rolls out and throws a pass to A2 at the back of the end zone that is ruled incomplete. Team A challenges that the pass was complete, but replays show that A2 only got one foot down inbounds and the call on the field is upheld. While the Referee is making his announcement, a new replay comes up that shows the QB stepping on the sideline at the B40 before releasing the pass. Team B challenges the play.\n",
-      "      Ruling: Reviewable. Both teams can challenge the same play. A's ball third-and-15 on the B40, reset the clock to the time when the QB stepped out of bounds, and start on the snap. A team cannot challenge the same play twice. It is important that all reviewable aspects of a play are confirmed by replay regardless of what is being challenged. Team A is charged with a challenge and a timeout.\n",
-      "    questions_and_answers:\n",
-      "      - question: What is the result of the second review?\n",
-      "        answer: |-\n",
-      "          The second review shows that the QB stepped on the sideline at the B40 before\n",
-      "          releasing the pass, and the play is ruled incomplete.\n",
-      "      - question: What is the overall result of the two reviews?\n",
-      "        answer: |-\n",
-      "          The first review upheld the call that A2 only got one foot down inbounds, and\n",
-      "          the second review showed that the QB stepped on the sideline before releasing\n",
-      "          the pass, resulting in an incomplete pass.\n",
-      "      - question: |-\n",
-      "          Based on the information provided, why is Team A charged with a challenge and a\n",
-      "          timeout?\n",
-      "        answer: |-\n",
-      "          Team A is charged with a challenge and a timeout because they challenged the\n",
-      "          same play twice, which is against the rules.\n",
-      "  - context: |-\n",
-      "      the amount available after transfer.. For international wire transfers, other\n",
-      "      fees may also apply, including those charged by recipient's financial\n",
-      "      institution, foreign taxes, and other fees that are part of the wire transfer\n",
-      "      process. We profit from markups associated with the currency conversion included\n",
-      "      in our exchange rate (determined solely by us). Before sending in foreign\n",
-      "      currency, you should consider factors that impact the total cost or the amount\n",
-      "      available after transfer., 2 = For international wire transfers, other fees may\n",
-      "      also apply, including those charged by recipient's financial institution,\n",
-      "      foreign taxes, and other fees that are part of the wire transfer process. We\n",
-      "      profit from markups associated with the currency conversion included in our\n",
-      "      exchange rate (determined solely by us). Before sending in foreign currency, you\n",
-      "      should consider factors that impact the total cost or the amount available after\n",
-      "      transfer.. Non-Bank of America Teller Withdrawal, 1 = Per transaction, greater\n",
-      "      of $5.00 OR 3% of the amount (maximum $10.00) when you use your ATM or debit\n",
-      "      card, or card number, to make a withdrawal, transfer or payment at another bank\n",
-      "      and it is processed as a cash disbursement.. Non-Bank of America Teller\n",
-      "      Withdrawal, 2 = Per transaction, greater of $5.00 OR 3% of the amount (maximum\n",
-      "      $10.00) when you use your ATM or debit card, or card number, to make a\n",
-      "      withdrawal, transfer or payment at another bank and it is processed as a cash\n",
-      "      disbursement.\n",
-      "    questions_and_answers:\n",
-      "      - question: What is the maximum amount charged for a non-Bank of America Teller\n",
-      "          Withdrawal?\n",
-      "        answer: $10.00\n",
-      "      - question: |-\n",
-      "          What are the different fees associated with international wire transfers and\n",
-      "          non-Bank of America Teller Withdrawals?\n",
-      "        answer: |-\n",
-      "          For international wire transfers, fees may include those charged by the\n",
-      "          recipient's financial institution, foreign taxes, and other fees that are part\n",
-      "          of the wire transfer process. We also profit from markups associated with the\n",
-      "          currency conversion. For non-Bank of America Teller Withdrawals, the fee is the\n",
-      "          greater of $5.00 or 3% of the amount, with a maximum of $10.00.\n",
-      "      - question: |-\n",
-      "          Given the fees for non-Bank of America Teller Withdrawals and international wire\n",
-      "          transfers, why might it be more cost-effective to use Bank of America's services\n",
-      "          for international wire transfers?\n",
-      "        answer: |-\n",
-      "          Using Bank of America's services for international wire transfers might be more\n",
-      "          cost-effective because, although there may be fees associated with the transfer,\n",
-      "          the bank determines the exchange rate markups solely, potentially offering a\n",
-      "          more favorable rate than other financial institutions. Additionally, there would\n",
-      "          be no fees for using a non-Bank of America ATM or debit card for the transfer.\n",
-      "          However, one should still consider all factors that could impact the total cost\n",
-      "          or the amount available after transfer.\n",
-      "  - context: \"Review all the features and benefits of your new account at bankofamerica.com/quickstart\\n\\\n",
-      "      For questions, schedule an appointment to visit a financial center at bankofamerica.com/appointments\\n\\\n",
-      "      Call us at 800.432.1000\\nAdditional fee waivers may be available to Bank of\\\n",
-      "      \\ America Private Bank and qualified Merrill Lynch Wealth Management \\xAE clients.\\\n",
-      "      \\ Please contact your advisor to learn more. Merrill Lynch, Pierce, Fenner &\\\n",
-      "      \\ Smith Incorporated (also referred to as 'MLPF&S' or 'Merrill') makes available\\\n",
-      "      \\ certain investment products sponsored, managed, distributed or provided by\\\n",
-      "      \\ companies that are affiliates of Bank of America Corporation ('BofA Corp.').\\\n",
-      "      \\ MLPF&S is a registered broker-dealer, registered investment advisor, Member\\\n",
-      "      \\ SIPC and a wholly owned subsidiary of BofA Corp.\\nInvestment products:\\nAre\\\n",
-      "      \\ Not FDIC Insured\\nAre Not Bank Guaranteed\\nMay Lose Value\\nBanking products\\\n",
-      "      \\ are provided by Bank of America, N.A. and affiliated banks, Members FDIC and\\\n",
-      "      \\ wholly owned subsidiaries of Bank of America Corporation.\"\n",
-      "    questions_and_answers:\n",
-      "      - question: What is the phone number to contact Bank of America?\n",
-      "        answer: 800.432.1000\n",
-      "      - question: What services does Bank of America offer through its website?\n",
-      "        answer: |-\n",
-      "          Bank of America offers account review, fee waiver inquiries, appointment\n",
-      "          scheduling, and customer service through its website.\n",
-      "      - question: |-\n",
-      "          If a Bank of America Private Bank or Merrill Lynch Wealth Management client\n",
-      "          contacts their advisor regarding additional fee waivers, what would be the\n",
-      "          outcome?\n",
-      "        answer: The client would learn more about any available fee waivers.\n",
-      "  - context: |-\n",
-      "      Cash, direct deposits, wire transfers: On the day we receive them.\n",
-      "      Checks: Usually the next business day if deposited before the financial center or ATM cutoff time.\n",
-      "      Mobile Check Deposit: Usually the next business day if deposited by applicable cutoff times. Please refer to Deposit Checks , then Help in the Mobile Banking app for additional details and terms and conditions.\n",
-      "      If we place a hold on your deposit, we'll let you know the hold reason and when your funds will be available. This is typically provided at the time of deposit but may also be mailed later. Deposits greater than $5,525 and checks deposited within the first 30 days of account opening may be held longer.\n",
-      "    questions_and_answers:\n",
-      "      - question: What is the usual availability of cash and wire transfers when received?\n",
-      "        answer: On the day they are received.\n",
-      "      - question: What is the general timeframe for checks to become available after\n",
-      "          deposit?\n",
-      "        answer: |-\n",
-      "          Checks are usually available the next business day if deposited before the\n",
-      "          financial center or ATM cutoff time.\n",
-      "      - question: |-\n",
-      "          If a check is deposited within the first 30 days of account opening and the\n",
-      "          amount is greater than $5,525, will it be held longer?\n",
-      "        answer: |-\n",
-      "          Yes, deposits greater than $5,525 and checks deposited within the first 30 days\n",
-      "          of account opening may be held longer.\n",
-      "  - context: |-\n",
-      "      Non-Bank of America ATMs, No ATM fee = $2.50. Non-Bank of America ATMs, For deposits, withdrawals, transfers or balance inquiries = In the U.S., plus any fee charged by the ATM's operator. Non-Bank of America ATMs, No ATM fee = $5.00. Non-Bank of America ATMs, For deposits, withdrawals, transfers or balance inquiries = Outside the U.S., plus any fee charged by the ATM's operator. Statement copies, No ATM fee = No fee. Statement copies, For deposits, withdrawals, transfers or balance inquiries = Paper copies available upon request. Printable statements are available in Online Banking.. Stop payment fee, No ATM fee = $30.00. Stop payment fee, For deposits, withdrawals, transfers or balance inquiries = For each request; WAIVED for requests on Bill Pay transactions. Cashier's checks, No ATM fee = $15.00. Cashier's checks, For deposits, withdrawals, transfers or balance inquiries = For each check\n",
-      "      of America debit card, and we'll round up your purchases to the nearest dollar amount and transfer the Build your savings automatically when you enroll in our Keep the Change savings program. Simply make everyday purchases with your Bank difference from your checking account to your savings account.\n",
-      "      Please see the Personal Schedule of Fees and Deposit Agreement and Disclosures for your account terms, and information on how to link eligible accounts to avoid the Monthly Maintenance Fee.\n",
-      "    questions_and_answers:\n",
-      "      - question: What is the fee for a cashier's check at a Non-Bank of America ATM?\n",
-      "        answer: $15.00\n",
-      "      - question: |-\n",
-      "          What are the fees for using a Non-Bank of America ATM for various services\n",
-      "          within the U.S. and outside the U.S.?\n",
-      "        answer: |-\n",
-      "          In the U.S., the fee for using a Non-Bank of America ATM for deposits,\n",
-      "          withdrawals, transfers, or balance inquiries is the ATM's operator fee plus\n",
-      "          $2.50. Outside the U.S., the fee for these services is the ATM's operator fee\n",
-      "          plus $5.00.\n",
-      "      - question: |-\n",
-      "          If you enroll in the Keep the Change savings program, how will your purchases be\n",
-      "          handled?\n",
-      "        answer: |-\n",
-      "          Your purchases will be rounded up to the nearest dollar amount and the\n",
-      "          difference will be transferred from your checking account to your savings\n",
-      "          account.\n",
-      "document_outline: Official playing rules of the National Football League 2022\n",
-      "domain: sports\n",
-      "\n",
-      "========== qna.yaml at workspaces/default/authoring/finance/qna.yaml ==========\n",
-      "seed_examples:\n",
-      "  - context: |-\n",
-      "      On A's kickoff from the A35, Team A has five players to the right of the kicker and five players to the left, all legally set. As the kicker approaches the ball, the wind blows the ball off the tee. Team A brings A1, the widest man, from outside the yard-line numbers in to be the holder. This leaves Team A with just one player outside the yard-line numbers on that side. The ball is kicked through the end zone.\n",
-      "      Ruling : B's ball, first-and-10 on B30 or re-kick A30. Illegal formation. Even though the holder counts toward either side for the purpose of five on each side, Team A must still have two players outside the yard-line numbers and two players, (other than the holder), between the inbounds line and the yard-line numbers.\n",
-      "    questions_and_answers:\n",
-      "      - question: |-\n",
-      "          How many players were initially on each side of Team A's kicker before the ball\n",
-      "          was blown off the tee?\n",
-      "        answer: |-\n",
-      "          There were five players on each side of Team A's kicker before the ball was\n",
-      "          blown off the tee.\n",
-      "      - question: |-\n",
-      "          What is the ruling for Team A's formation after the ball was blown off the tee\n",
-      "          and A1 came in as the holder?\n",
-      "        answer: |-\n",
-      "          The ruling is that it is an illegal formation. Team A must have two players\n",
-      "          outside the yard-line numbers and two players between the inbounds line and the\n",
-      "          yard-line numbers, other than the holder.\n",
-      "      - question: |-\n",
-      "          Based on the information provided, why was the kick through the end zone\n",
-      "          considered illegal?\n",
-      "        answer: |-\n",
-      "          The kick through the end zone was considered illegal because Team A had an\n",
-      "          illegal formation at the time of the kick.\n",
-      "  - context: |-\n",
-      "      Second-and-5 on A30. A2 takes a handoff from a shotgun or T-QB and starts to\n",
-      "      sweep around the right end. As he is (a) behind the normal position of the right\n",
-      "      tackle, or (b) behind the normal position of the tight end, he stops and changes\n",
-      "      direction toward the middle of the field. Left tackle A3 sees A2 change\n",
-      "      direction, runs toward him, and forcibly blocks defensive end B2 at the A28 in\n",
-      "      the chest with his head (not UOH), forearm, or shoulder. The block occurs behind\n",
-      "      the normal right guard position and is parallel to the line of scrimmage. A2\n",
-      "      runs to the 50, where he is tackled.\n",
-      "    questions_and_answers:\n",
-      "      - question: Which player forcibly blocks defensive end B2?\n",
-      "        answer: Left tackle A3\n",
-      "      - question: |-\n",
-      "          Based on the information provided, can it be inferred that A2's change of\n",
-      "          direction was a planned play or a spontaneous decision?\n",
-      "        answer: |-\n",
-      "          The text does not provide enough information to definitively answer this\n",
-      "          question. It could be interpreted either way, depending on the context of the\n",
-      "          overall game strategy.\n",
-      "  - context: \"\\xB7 To help you avoid fees, we won't authorize ATM withdrawals or everyday\\\n",
-      "      \\ debit card purchases when you don't have enough money in your account at the\\\n",
-      "      \\ time of the transaction.\\n\\xB7 When we determine you don't have enough money\\\n",
-      "      \\ in your account to cover other items such as checks or scheduled payments,\\\n",
-      "      \\ we'll either authorize and pay the item and overdraw your account (an overdraft\\\n",
-      "      \\ item),  or decline or return the item unpaid (a returned item). When 1 this\\\n",
-      "      \\ happens, you may be charged a fee. See details below.\\n\\u2022 We offer two\\\n",
-      "      \\ overdraft setting options for how you want us to process your other transactions.\"\n",
-      "    questions_and_answers:\n",
-      "      - question: |-\n",
-      "          What happens when there is not enough money in the account to cover other items\n",
-      "          like checks or scheduled payments?\n",
-      "        answer: |-\n",
-      "          The bank will either authorize and pay the item and overdraw the account, or\n",
-      "          decline or return the item unpaid.\n",
-      "      - question: |-\n",
-      "          What are the two overdraft setting options the bank offers for processing other\n",
-      "          transactions?\n",
-      "        answer: The bank offers two overdraft setting options for processing other\n",
-      "          transactions.\n",
-      "      - question: |-\n",
-      "          If the bank overdraws an account and charges a fee, why might a customer\n",
-      "          consider changing their overdraft setting option?\n",
-      "        answer: |-\n",
-      "          A customer might consider changing their overdraft setting option to avoid or\n",
-      "          reduce the frequency of overdraft fees.\n",
-      "  - context: |-\n",
-      "      the amount available after transfer.. For international wire transfers, other\n",
-      "      fees may also apply, including those charged by recipient's financial\n",
-      "      institution, foreign taxes, and other fees that are part of the wire transfer\n",
-      "      process. We profit from markups associated with the currency conversion included\n",
-      "      in our exchange rate (determined solely by us). Before sending in foreign\n",
-      "      currency, you should consider factors that impact the total cost or the amount\n",
-      "      available after transfer., 2 = For international wire transfers, other fees may\n",
-      "      also apply, including those charged by recipient's financial institution,\n",
-      "      foreign taxes, and other fees that are part of the wire transfer process. We\n",
-      "      profit from markups associated with the currency conversion included in our\n",
-      "      exchange rate (determined solely by us). Before sending in foreign currency, you\n",
-      "      should consider factors that impact the total cost or the amount available after\n",
-      "      transfer.. Non-Bank of America Teller Withdrawal, 1 = Per transaction, greater\n",
-      "      of $5.00 OR 3% of the amount (maximum $10.00) when you use your ATM or debit\n",
-      "      card, or card number, to make a withdrawal, transfer or payment at another bank\n",
-      "      and it is processed as a cash disbursement.. Non-Bank of America Teller\n",
-      "      Withdrawal, 2 = Per transaction, greater of $5.00 OR 3% of the amount (maximum\n",
-      "      $10.00) when you use your ATM or debit card, or card number, to make a\n",
-      "      withdrawal, transfer or payment at another bank and it is processed as a cash\n",
-      "      disbursement.\n",
-      "    questions_and_answers:\n",
-      "      - question: What is the maximum amount charged for a non-Bank of America Teller\n",
-      "          Withdrawal?\n",
-      "        answer: $10.00\n",
-      "      - question: |-\n",
-      "          What are the different fees associated with international wire transfers and\n",
-      "          non-Bank of America Teller Withdrawals?\n",
-      "        answer: |-\n",
-      "          For international wire transfers, fees may include those charged by the\n",
-      "          recipient's financial institution, foreign taxes, and other fees that are part\n",
-      "          of the wire transfer process. We also profit from markups associated with the\n",
-      "          currency conversion. For non-Bank of America Teller Withdrawals, the fee is the\n",
-      "          greater of $5.00 or 3% of the amount, with a maximum of $10.00.\n",
-      "      - question: |-\n",
-      "          Given the fees for non-Bank of America Teller Withdrawals and international wire\n",
-      "          transfers, why might it be more cost-effective to use Bank of America's services\n",
-      "          for international wire transfers?\n",
-      "        answer: |-\n",
-      "          Using Bank of America's services for international wire transfers might be more\n",
-      "          cost-effective because, although there may be fees associated with the transfer,\n",
-      "          the bank determines the exchange rate markups solely, potentially offering a\n",
-      "          more favorable rate than other financial institutions. Additionally, there would\n",
-      "          be no fees for using a non-Bank of America ATM or debit card for the transfer.\n",
-      "          However, one should still consider all factors that could impact the total cost\n",
-      "          or the amount available after transfer.\n",
-      "  - context: |-\n",
-      "      We don't charge overdraft fees on this account. To help you avoid overdrawing your account, transactions will be declined and returned unpaid when you don't have enough money in your account.\n",
-      "      If this happens, you won't be charged a bank overdraft fee, but the merchant or third party could charge you a fee. For example, you may be charged a late fee if the payment isn't received on time.\n",
-      "      There may still be times when your account could have a negative balance, but we won't charge an overdraft fee.\n",
-      "    questions_and_answers:\n",
-      "      - question: Does this account charge overdraft fees?\n",
-      "        answer: No, this account does not charge overdraft fees.\n",
-      "      - question: |-\n",
-      "          What happens when a transaction is made without sufficient funds in this\n",
-      "          account?\n",
-      "        answer: |-\n",
-      "          The transaction is declined and returned unpaid, and the merchant or third party\n",
-      "          could charge a fee.\n",
-      "      - question: |-\n",
-      "          If a payment isn't received on time due to a declined transaction, could the\n",
-      "          payee charge a late fee?\n",
-      "        answer: Yes, the payee could charge a late fee.\n",
-      "  - context: |-\n",
-      "      Non-Bank of America ATMs, No ATM fee = $2.50. Non-Bank of America ATMs, For deposits, withdrawals, transfers or balance inquiries = In the U.S., plus any fee charged by the ATM's operator. Non-Bank of America ATMs, No ATM fee = $5.00. Non-Bank of America ATMs, For deposits, withdrawals, transfers or balance inquiries = Outside the U.S., plus any fee charged by the ATM's operator. Statement copies, No ATM fee = No fee. Statement copies, For deposits, withdrawals, transfers or balance inquiries = Paper copies available upon request. Printable statements are available in Online Banking.. Stop payment fee, No ATM fee = $30.00. Stop payment fee, For deposits, withdrawals, transfers or balance inquiries = For each request; WAIVED for requests on Bill Pay transactions. Cashier's checks, No ATM fee = $15.00. Cashier's checks, For deposits, withdrawals, transfers or balance inquiries = For each check\n",
-      "      of America debit card, and we'll round up your purchases to the nearest dollar amount and transfer the Build your savings automatically when you enroll in our Keep the Change savings program. Simply make everyday purchases with your Bank difference from your checking account to your savings account.\n",
-      "      Please see the Personal Schedule of Fees and Deposit Agreement and Disclosures for your account terms, and information on how to link eligible accounts to avoid the Monthly Maintenance Fee.\n",
-      "    questions_and_answers:\n",
-      "      - question: What is the fee for a cashier's check at a Non-Bank of America ATM?\n",
-      "        answer: $15.00\n",
-      "      - question: |-\n",
-      "          What are the fees for using a Non-Bank of America ATM for various services\n",
-      "          within the U.S. and outside the U.S.?\n",
-      "        answer: |-\n",
-      "          In the U.S., the fee for using a Non-Bank of America ATM for deposits,\n",
-      "          withdrawals, transfers, or balance inquiries is the ATM's operator fee plus\n",
-      "          $2.50. Outside the U.S., the fee for these services is the ATM's operator fee\n",
-      "          plus $5.00.\n",
-      "      - question: |-\n",
-      "          If you enroll in the Keep the Change savings program, how will your purchases be\n",
-      "          handled?\n",
-      "        answer: |-\n",
-      "          Your purchases will be rounded up to the nearest dollar amount and the\n",
-      "          difference will be transferred from your checking account to your savings\n",
-      "          account.\n",
-      "document_outline: Account information for a specific bank\n",
-      "domain: banking\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for contribution in contributions:\n",
     "    qna_output_path = AUTHORING_OUTPUT_DIR / contribution[\"prefix\"] / \"qna.yaml\"\n",
@@ -1243,642 +622,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "id": "e2c6e31b-e8a9-406c-b2dc-27433c8fd8ec",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
-      "To disable this warning, you can either:\n",
-      "\t- Avoid using `tokenizers` before the fork if possible\n",
-      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!pip install -qq datasets transformers"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "id": "ab2c9ed2-8ba8-4959-8e01-81625b81d286",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e3ee0f8d1c89435e927863ba0ffa5923",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0b69647ea3d241a985a926b371241210",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a54a09d2748d4a01b5a57fda6344857a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b2f6b9b7954b4b66abac7e8b385c97d3",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b86ffea597dc4078b4264d032def50ea",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5934aacd5ebc4898a4e1c7949b9894a4",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/8990 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9ac6364734404a42a42ba953149edc7b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Filter:   0%|          | 0/8990 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7fd4213d07d6458595636d4a3c3d1189",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3c386876528d43baad39def1c1ebf488",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "88348c0f21fe43eb83e2c1953aa54c7d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fa7363d80f5b423e8cd8304547fabafd",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8e555e8db38541fda4b5481ecd356f1a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "efcce14d53f3457b9459e64c4549dbee",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/50 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "702b73ba86f845c280af16188d71f2b6",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Filter:   0%|          | 0/50 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6af9b75043be419787fcf9b20be84e5b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "020f450c181946aa871170b8c3ccb951",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "52f50911b9e64f8fabe8aa3c688c10ac",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "45413ce86ec1451d9a2be28c94d28555",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "594299e41ccf4f5a91a02131b3f72d0e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "61b518e7616d4ebe8ecc3daa3725178c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/25 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8a3e43b437204f70bb0a8eb63bee9c17",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Filter:   0%|          | 0/25 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b71da1ee64734d07be712547d1bffadc",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e9619323ce994418a9619723773b05bf",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dd4c107d13f245f3a1be229c65a06531",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5f546b7133c843a5a6698aac7211b144",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "86b226be63c544b5ac18d962bba8a21e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8139b4f2aadc44aeb8d485d023357569",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/8990 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a0b5a1c3923f492f827202a38761d32b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Filter:   0%|          | 0/8990 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7913d0b16534410880b700664c31e1df",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1f4920eacce04cc49730fbc02c32b993",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6178b789c0474c948c891ea5e3006719",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "16a4e0ce42ec49529ba6d0ee904e854e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b44d89b157e84f5881d0c0658ecff86b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4d4f24315dac4cdd9e99722f826c3dae",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/50 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "63ab41e4ab964457a5cd05de412f1502",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Filter:   0%|          | 0/50 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "26d64b525680413ca786217d09ced396",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "65ad5a34887446c6889ab6457dbf6116",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a07ec71549fd4e64b180a2c6b673e175",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0474ba5867a842d98ed30b9d396e0539",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "115d5a63986a48e0a274a350668c01c9",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bc02423dca15437b94d739a84680589c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/25 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "efd64c3801f44885ab625978fa8dd252",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Filter:   0%|          | 0/25 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "89bc5361ddc94ca887ae1969ee52659d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Creating json from Arrow format:   0%|          | 0/16 [00:00<?, ?ba/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Seed data contains 18130 rows\n",
-      "Results saved to: workspaces/default/sdg/seed_data.jsonl\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from utils.create_seed_dataset import get_seed_dataset, safe_concatenate_datasets\n",
     "\n",
@@ -1907,49 +664,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "id": "a6936825-31c1-4b46-a1af-2fb46f50158d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "pyarrow.Table\n",
-      "document_outline: string\n",
-      "document_title: string\n",
-      "domain: string\n",
-      "icl_document: string\n",
-      "icl_query_1: string\n",
-      "icl_response_1: string\n",
-      "icl_query_2: string\n",
-      "icl_response_2: string\n",
-      "icl_query_3: string\n",
-      "icl_response_3: string\n",
-      "document: string\n",
-      "----\n",
-      "document_outline: [[\"Account information for a specific bank\"]]\n",
-      "document_title: [[\"2022-nfl-rulebook-final\"]]\n",
-      "domain: [[\"banking\"]]\n",
-      "icl_document: [[\"On A's kickoff from the A35, Team A has five players to the right of the kicker and five players to the left, all legally set. As the kicker approaches the ball, the wind blows the ball off the tee. Team A brings A1, the widest man, from outside the yard-line numbers in to be the holder. This leaves Team A with just one player outside the yard-line numbers on that side. The ball is kicked through the end zone.\n",
-      "Ruling : B's ball, first-and-10 on B30 or re-kick A30. Illegal formation. Even though the holder counts toward either side for the purpose of five on each side, Team A must still have two players outside the yard-line numbers and two players, (other than the holder), between the inbounds line and the yard-line numbers.\"]]\n",
-      "icl_query_1: [[\"How many players were initially on each side of Team A's kicker before the ball\n",
-      "was blown off the tee?\"]]\n",
-      "icl_response_1: [[\"There were five players on each side of Team A's kicker before the ball was\n",
-      "blown off the tee.\"]]\n",
-      "icl_query_2: [[\"What is the ruling for Team A's formation after the ball was blown off the tee\n",
-      "and A1 came in as the holder?\"]]\n",
-      "icl_response_2: [[\"The ruling is that it is an illegal formation. Team A must have two players\n",
-      "outside the yard-line numbers and two players between the inbounds line and the\n",
-      "yard-line numbers, other than the holder.\"]]\n",
-      "icl_query_3: [[\"Based on the information provided, why was the kick through the end zone\n",
-      "considered illegal?\"]]\n",
-      "icl_response_3: [[\"The kick through the end zone was considered illegal because Team A had an\n",
-      "illegal formation at the time of the kick.\"]]\n",
-      "...\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(seed_data.data.table.slice(length=1))"
    ]

--- a/notebooks/instructlab-knowledge/instructlab-knowledge.ipynb
+++ b/notebooks/instructlab-knowledge/instructlab-knowledge.ipynb
@@ -151,6 +151,8 @@
    "source": [
     "import json\n",
     "\n",
+    "json_files = []\n",
+    "\n",
     "for file in files:\n",
     "    doc = doc_converter.convert(source=file).document\n",
     "    doc_dict = doc.export_to_dict()\n",
@@ -158,7 +160,8 @@
     "    json_output_path = CONVERSION_OUTPUT_DIR / f\"{file.stem}.json\"\n",
     "    with open(json_output_path, \"w\") as f:\n",
     "        json.dump(doc_dict, f)\n",
-    "        print(f\"Path of JSON output is: {Path(json_output_path).resolve()}\")"
+    "        print(f\"Path of JSON output is: {Path(json_output_path).resolve()}\")\n",
+    "        json_files.append(json_output_path)"
    ]
   },
   {
@@ -236,7 +239,8 @@
    "source": [
     "all_chunks = []\n",
     "docs = []\n",
-    "for file in files:\n",
+    "for file in json_files:\n",
+    "    # reconvert the docling JSON for chunking\n",
     "    doc = DocumentConverter().convert(source=file)\n",
     "    docs.append(doc)\n",
     "    \n",
@@ -335,8 +339,8 @@
     "dataset = {}\n",
     "for doc in docs:\n",
     "    print(f\"Chunking and filtering document {doc.document.name}\")\n",
-    "\n",
-    "    chunks = list(chunker.chunk(dl_doc=doc.document))\n",
+    "    \n",
+    "    # get_qa_chunks expects a list[DocChunk] which we already have from chunk_objs in the chunking section\n",
     "    qa_chunks = list(get_qa_chunks(doc.document.name, chunk_objs, filters)) #TODO: decouple reference to chunk_objs from above)\n",
     "    dataset[doc.document.name] = qa_chunks\n",
     "    \n",

--- a/notebooks/instructlab-knowledge/instructlab-knowledge.ipynb
+++ b/notebooks/instructlab-knowledge/instructlab-knowledge.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# 🐶 Data Pre-Processing: From source PDF to SDG-ready\n",
     "\n",
-    "This notebook goes through each of the stages of data pre-processing. Directory-based conventions are used to save intermediate results as a PDF is converted and chunked, QA generation is performed to create a `qna.yaml` file, and finally everything is combined into the inputs for SDG.\n",
+    "This notebook goes through each of the stages of data pre-processing. Directory-based conventions are used to save intermediate results as a PDF is converted and chunked and QA generation is performed to create a `qna.yaml` file for each knowledge contribution. At the end everything is combined into the inputs for SDG.\n",
     "\n",
     "Once a SDG seed dataset is created, a user can run through an SDG notebook and generate samples.\n",
     "\n",
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "id": "0acd026f-65bd-4393-bb40-f8aa8bd6828b",
    "metadata": {},
    "outputs": [],
@@ -62,12 +62,12 @@
    "source": [
     "## Data Gathering\n",
     "\n",
-    "Ensure the necessary PDF files are in `SOURCE_DOCUMENT_DIR`."
+    "TODO: Add documentation about domain and summary here, clear out second contribution example"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 18,
    "id": "26501e2f-7215-441f-9efa-075f87024893",
    "metadata": {},
    "outputs": [
@@ -75,13 +75,47 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Files to convert: [PosixPath('workspaces/default/source_documents/2022-nfl-rulebook-final.pdf'), PosixPath('workspaces/default/source_documents/BofA_InterestChecking_en_ADA.pdf'), PosixPath('workspaces/default/source_documents/2502.01618v3.pdf')]\n"
+      "Files to convert:\n",
+      "[PosixPath('workspaces/default/source_documents/nfl/2022-nfl-rulebook-final.pdf')]\n",
+      "[PosixPath('workspaces/default/source_documents/finance/BofA_InterestChecking_en_ADA.pdf'), PosixPath('workspaces/default/source_documents/finance/Advantag Savings.pdf')]\n"
      ]
     }
    ],
    "source": [
-    "files = list(SOURCE_DOCUMENT_DIR.glob(\"*.pdf\"))\n",
-    "print(f\"Files to convert: {files}\")"
+    "# struct would have document outline, domain, and path to pdf's for each contribution\n",
+    "\n",
+    "contribution_path = Path(SOURCE_DOCUMENT_DIR / \"nfl\")\n",
+    "contribution_prefix = \"nfl\"\n",
+    "contribution_domain = \"sports\" \n",
+    "contribution_summary = \"Official playing rules of the National Football League 2022\"\n",
+    "\n",
+    "contribution1 = {\"path\": contribution_path, \"prefix\": contribution_prefix, \"domain\": contribution_domain, \"summary\": contribution_summary}\n",
+    "\n",
+    "contribution_path2 = Path(SOURCE_DOCUMENT_DIR / \"finance\")\n",
+    "contribution_prefix2 = \"finance\"\n",
+    "contribution_domain2 = \"banking\" \n",
+    "contribution_summary2 = \"Account information for a specific bank\"\n",
+    "\n",
+    "contribution2 = {\"path\": contribution_path2, \"prefix\": contribution_prefix2, \"domain\": contribution_domain2, \"summary\": contribution_summary2}\n",
+    "\n",
+    "contributions = []\n",
+    "contributions.append(contribution1)\n",
+    "contributions.append(contribution2)\n",
+    "\n",
+    "for contribution in contributions:\n",
+    "    contribution[\"files\"] = list(contribution[\"path\"].glob(\"*.pdf\"))\n",
+    "\n",
+    "print(f\"Files to convert:\")\n",
+    "for contribution in contributions:\n",
+    "    print(f\"{contribution[\"files\"]}\")\n",
+    "    conv_output_dir = CONVERSION_OUTPUT_DIR / contribution[\"prefix\"]\n",
+    "    conv_output_dir.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "    chunking_output_dir = CHUNKING_OUTPUT_DIR / contribution[\"prefix\"]\n",
+    "    chunking_output_dir.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "    authoring_output_dir = AUTHORING_OUTPUT_DIR / contribution[\"prefix\"]\n",
+    "    authoring_output_dir.mkdir(parents=True, exist_ok=True)"
    ]
   },
   {
@@ -96,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "id": "b91d4b2e-19cd-46e7-a912-ba9b2904c7cd",
    "metadata": {},
    "outputs": [],
@@ -118,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "id": "157c5e02-edd1-44f6-b20f-f6b4bda1aae7",
    "metadata": {},
    "outputs": [],
@@ -148,42 +182,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 19,
    "id": "a200039c-b8b2-4087-88ba-7bfb0e393cc9",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/amaredia/dev/examples/notebooks/instructlab-knowledge/venv/lib/python3.12/site-packages/torch/utils/data/dataloader.py:683: UserWarning: 'pin_memory' argument is set as true but not supported on MPS now, then device pinned memory won't be used.\n",
-      "  warnings.warn(warn_msg)\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Path of JSON output is: /Users/amaredia/dev/examples/notebooks/instructlab-knowledge/workspaces/default/conversion/2022-nfl-rulebook-final.json\n",
-      "Path of JSON output is: /Users/amaredia/dev/examples/notebooks/instructlab-knowledge/workspaces/default/conversion/BofA_InterestChecking_en_ADA.json\n",
-      "Path of JSON output is: /Users/amaredia/dev/examples/notebooks/instructlab-knowledge/workspaces/default/conversion/2502.01618v3.json\n"
+      "Path of JSON output is: /Users/amaredia/dev/examples/notebooks/instructlab-knowledge/workspaces/default/conversion/nfl/2022-nfl-rulebook-final.json\n",
+      "Path of JSON output is: /Users/amaredia/dev/examples/notebooks/instructlab-knowledge/workspaces/default/conversion/finance/BofA_InterestChecking_en_ADA.json\n",
+      "Path of JSON output is: /Users/amaredia/dev/examples/notebooks/instructlab-knowledge/workspaces/default/conversion/finance/Advantag Savings.json\n"
      ]
     }
    ],
    "source": [
     "import json\n",
     "\n",
-    "json_files = []\n",
-    "\n",
-    "for file in files:\n",
-    "    doc = doc_converter.convert(source=file).document\n",
-    "    doc_dict = doc.export_to_dict()\n",
-    "\n",
-    "    json_output_path = CONVERSION_OUTPUT_DIR / f\"{file.stem}.json\"\n",
-    "    with open(json_output_path, \"w\") as f:\n",
-    "        json.dump(doc_dict, f)\n",
-    "        print(f\"Path of JSON output is: {Path(json_output_path).resolve()}\")\n",
-    "        json_files.append(json_output_path)"
+    "for contribution in contributions:\n",
+    "    contribution[\"json_files\"] = []\n",
+    "    for file in contribution[\"files\"]:\n",
+    "        doc = doc_converter.convert(source=file).document\n",
+    "        doc_dict = doc.export_to_dict()\n",
+    "    \n",
+    "        json_output_path = CONVERSION_OUTPUT_DIR / contribution[\"prefix\"] / f\"{file.stem}.json\"\n",
+    "        with open(json_output_path, \"w\") as f:\n",
+    "            json.dump(doc_dict, f)\n",
+    "            print(f\"Path of JSON output is: {Path(json_output_path).resolve()}\")\n",
+    "            json_files.append(json_output_path.resolve())"
    ]
   },
   {
@@ -217,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 20,
    "id": "50df9d91-add4-46a1-a69d-0f7f9f69542e",
    "metadata": {},
    "outputs": [],
@@ -254,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 21,
    "id": "db983c05-4aa6-4261-9283-2adab69bfbd3",
    "metadata": {},
    "outputs": [
@@ -271,31 +297,32 @@
      "text": [
       "Extracted 1798 chunks from 2022-nfl-rulebook-final\n",
       "Extracted 10 chunks from BofA_InterestChecking_en_ADA\n",
-      "Extracted 52 chunks from 2502.01618v3\n"
+      "Extracted 5 chunks from Advantag Savings\n",
+      "Extracted 1798 chunks from 2022-nfl-rulebook-final\n",
+      "Extracted 10 chunks from BofA_InterestChecking_en_ADA\n",
+      "Extracted 5 chunks from Advantag Savings\n"
      ]
     }
    ],
    "source": [
-    "all_chunks = []\n",
-    "docs = []\n",
-    "for file in json_files:\n",
-    "    # reconvert the docling JSON for chunking\n",
-    "    doc = DocumentConverter().convert(source=file)\n",
+    "for contribution in contributions:\n",
+    "    contribution[\"all_chunks\"] = []\n",
+    "    contribution[\"docs\"] = []\n",
+    "    for file in json_files:\n",
+    "        # reconvert the docling JSON for chunking\n",
+    "        doc = DocumentConverter().convert(source=file)\n",
+    "        \n",
+    "        chunk_iter = chunker.chunk(dl_doc=doc.document)\n",
+    "        chunk_objs = list(chunk_iter)\n",
+    "        chunks = [chunker.contextualize(chunk=chunk) for chunk in chunk_objs]\n",
     "    \n",
-    "    chunk_iter = chunker.chunk(dl_doc=doc.document)\n",
-    "    chunk_objs = list(chunk_iter)\n",
-    "    chunks = [chunker.contextualize(chunk=chunk) for chunk in chunk_objs]\n",
-    "\n",
-    "    print(f\"Extracted {len(chunks)} chunks from {doc.document.name}\")\n",
-    "    \n",
-    "    for chunk in chunks:\n",
-    "        c = dict(chunk=chunk, file=doc.document.name)\n",
-    "        all_chunks.append(c)\n",
-    "    \n",
-    "    docs.append(dict(chunk_objs=chunk_objs,file=doc.document.name))\n",
-    "\n",
-    "\n",
-    "# TODO: support multiple files save all chunks to single file for review"
+    "        print(f\"Extracted {len(chunks)} chunks from {doc.document.name}\")\n",
+    "        \n",
+    "        for chunk in chunks:\n",
+    "            c = dict(chunk=chunk, file=doc.document.name)\n",
+    "            contribution[\"all_chunks\"].append(c)\n",
+    "        \n",
+    "        contribution[\"docs\"].append(dict(chunk_objs=chunk_objs,file=doc.document.name))"
    ]
   },
   {
@@ -310,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 22,
    "id": "4fdf34c7-9829-43d2-bf9f-7d1d55bb6a4c",
    "metadata": {},
    "outputs": [
@@ -324,7 +351,7 @@
     }
    ],
    "source": [
-    "print(all_chunks[0][\"chunk\"])"
+    "print(contributions[0][\"all_chunks\"][0][\"chunk\"])"
    ]
   },
   {
@@ -339,16 +366,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 25,
    "id": "6e70d576-a2bc-4274-b660-1cbe051968b1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Path of chunks JSON is: /Users/amaredia/dev/examples/notebooks/instructlab-knowledge/workspaces/default/chunking/nfl/chunks.jsonl\n",
+      "Path of chunks JSON is: /Users/amaredia/dev/examples/notebooks/instructlab-knowledge/workspaces/default/chunking/finance/chunks.jsonl\n"
+     ]
+    }
+   ],
    "source": [
-    "chunks_file_path = CHUNKING_OUTPUT_DIR / \"chunks.jsonl\"\n",
-    "with open(chunks_file_path, \"w\", encoding=\"utf-8\") as file:\n",
-    "    for chunk in all_chunks:\n",
-    "        json.dump(chunk, file)\n",
-    "        file.write(\"\\n\")"
+    "for contribution in contributions:\n",
+    "    chunks_file_path = CHUNKING_OUTPUT_DIR / contribution[\"prefix\"] / \"chunks.jsonl\"\n",
+    "    with open(chunks_file_path, \"w\", encoding=\"utf-8\") as file:\n",
+    "        for chunk in contribution[\"all_chunks\"]:\n",
+    "            json.dump(chunk, file)\n",
+    "            file.write(\"\\n\")\n",
+    "        print(f\"Path of chunks JSON is: {Path(chunks_file_path).resolve()}\")\n"
    ]
   },
   {
@@ -361,7 +399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 26,
    "id": "86c48e52-cda7-48ac-84dc-0b844aed5f98",
    "metadata": {},
    "outputs": [
@@ -385,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 27,
    "id": "2a165c38-843b-4c89-a8ad-6195b998e284",
    "metadata": {},
    "outputs": [
@@ -397,8 +435,14 @@
       "Created dataset 2022-nfl-rulebook-final with 720 QA chunks\n",
       "Chunking and filtering document BofA_InterestChecking_en_ADA\n",
       "Created dataset BofA_InterestChecking_en_ADA with 8 QA chunks\n",
-      "Chunking and filtering document 2502.01618v3\n",
-      "Created dataset 2502.01618v3 with 45 QA chunks\n"
+      "Chunking and filtering document Advantag Savings\n",
+      "Created dataset Advantag Savings with 5 QA chunks\n",
+      "Chunking and filtering document 2022-nfl-rulebook-final\n",
+      "Created dataset 2022-nfl-rulebook-final with 720 QA chunks\n",
+      "Chunking and filtering document BofA_InterestChecking_en_ADA\n",
+      "Created dataset BofA_InterestChecking_en_ADA with 8 QA chunks\n",
+      "Chunking and filtering document Advantag Savings\n",
+      "Created dataset Advantag Savings with 5 QA chunks\n"
      ]
     }
    ],
@@ -409,15 +453,16 @@
     "    lambda chunk: len(str(chunk.text)) > 500\n",
     "]\n",
     "\n",
-    "dataset = {}\n",
-    "for doc in docs:\n",
-    "    print(f\"Chunking and filtering document {doc[\"file\"]}\")\n",
-    "    \n",
-    "    # get_qa_chunks expects a list[DocChunk] which we already have from doc[\"chunk_objs\"] in the chunking section\n",
-    "    qa_chunks = list(get_qa_chunks(doc[\"file\"], doc[\"chunk_objs\"], filters)) #TODO: decouple reference to chunk_objs from above)\n",
-    "    dataset[doc[\"file\"]] = qa_chunks\n",
-    "    \n",
-    "    print(f\"Created dataset {doc[\"file\"]} with {len(qa_chunks)} QA chunks\")"
+    "for contribution in contributions:\n",
+    "    contribution[\"dataset\"] = {}\n",
+    "    for doc in contribution[\"docs\"]:\n",
+    "        print(f\"Chunking and filtering document {doc[\"file\"]}\")\n",
+    "        \n",
+    "        # get_qa_chunks expects a list[DocChunk] which we already have from doc[\"chunk_objs\"] in the chunking section\n",
+    "        qa_chunks = list(get_qa_chunks(doc[\"file\"], doc[\"chunk_objs\"], filters)) #TODO: decouple reference to chunk_objs from above)\n",
+    "        contribution[\"dataset\"][doc[\"file\"]] = qa_chunks\n",
+    "        \n",
+    "        print(f\"Created dataset {doc[\"file\"]} with {len(qa_chunks)} QA chunks\")"
    ]
   },
   {
@@ -436,7 +481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 28,
    "id": "874d4de8",
    "metadata": {
     "tags": [
@@ -452,7 +497,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 29,
    "id": "b702267e-f550-4bc2-bce4-c0fcecbbd292",
    "metadata": {},
    "outputs": [],
@@ -478,7 +523,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 30,
    "id": "f1197d4e-8354-45e3-9ec9-85c78ba36548",
    "metadata": {},
    "outputs": [],
@@ -496,7 +541,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 31,
    "id": "e57edff5-9a13-47fb-9248-9140ae5baaca",
    "metadata": {},
    "outputs": [
@@ -519,7 +564,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:06<00:00,  3.47s/it]\n"
+      "  0%|                                                                                                                                                                                                                                                             | 0/2 [00:00<?, ?it/s]PromptTypes.ANSWER prompt not available for types ['reasoning']\n",
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:06<00:00,  3.35s/it]\n"
      ]
     },
     {
@@ -554,7 +600,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:08<00:00,  4.06s/it]\n"
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:07<00:00,  3.98s/it]\n"
      ]
     },
     {
@@ -563,7 +609,18 @@
      "text": [
       "BofA_InterestChecking_en_ADA: Status.SUCCESS\n",
       "processing chunks that looks like:\n",
-      "Large language models (LLMs) have achieved significant performance gains via scaling up model sizes and/or data. However, recent evidence suggests diminishing returns from such approaches, motivating scaling the computation spent at inference time. Existing inference-time scaling methods, usually with reward models, cast the task as a search problem, which tends to be vulnerable to reward hacking as a consequence of approximation errors in reward models. In this paper, we instead cast inference-time scaling as a probabilistic inference task and leverage sampling-based techniques to explore the typical set of the state distribution of a state-space model with an approximate likelihood, rather than optimize for its mode directly. We propose a novel inference-time scaling approach by adapting particle-based Monte Carlo methods to this task. Our empirical evaluation demonstrates that our methods have a 4-16x better scaling rate over our deterministic search counterparts on various challenging mathematical reasoning tasks. Using our approach, we show that Qwen2.5-Math-1.5B-Instruct can surpass GPT4o accuracy in only 4 rollouts, while Qwen2.5Math-7B-Instruct scales to o1 level accuracy in only 32 rollouts. Our work not only presents an effective method to inference-time scaling, but also connects the rich literature in probabilistic inference with inference-time scaling of LLMs to develop more robust algorithms in future work. Code, videos, and further information available at probabilistic-inference-scaling.github.io/ .\n",
+      "FDIC\n",
+      "Coverage\n",
+      "This account is insured by the Federal Deposit Insurance Corporation (FDIC) and is backed by the U.S. government. The standard insurance amount is $250,000 per depositor, per insured bank, for each account ownership category.\n",
+      "Monthly Maintenance Fee\n",
+      "$8.00\n",
+      "each month\n",
+      "(We'll waive this fee for the first 6 months.)\n",
+      "You can avoid the Monthly Maintenance Fee when you meet ONE of the following requirements during each statement cycle:\n",
+      "· Maintain a minimum daily balance of $500 or more in your account, OR\n",
+      "· Ask us to link your account to your Bank of America Advantage Relationship Banking ® , Bank of America Advantage  with Tiered Interest Checking or Bank of America Advantage ® ® Regular Checking account (first 4 savings accounts), OR\n",
+      "· An owner of this account is under the age of 25 (fiduciary accounts don't qualify), OR\n",
+      "· Be a member of the Preferred Rewards program. Learn more at bankofamerica.com/preferred-rewards, or visit your local financial center.\n",
       "Selected 2 contexts\n"
      ]
     },
@@ -571,14 +628,100 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:08<00:00,  4.08s/it]"
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:06<00:00,  3.29s/it]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2502.01618v3: Status.SUCCESS\n"
+      "Advantag Savings: Status.SUCCESS\n",
+      "processing chunks that looks like:\n",
+      "This edition of the Official Playing Rules of the  National Football League  contains all current rules governing the playing of professional football that are in effect for the 2022 NFL season. Member clubs of the League may amend the rules from time to time, pursuant to the applicable voting procedures of the NFL Constitution and Bylaws.\n",
+      "Any intra-League dispute or call for interpretation in connection with these rules will be decided by the Commissioner of the League, whose ruling will be final.\n",
+      "Because inter-conference games are played throughout the preseason, regular season, and postseason in  the  NFL, all  rules contained in  this  book apply uniformly to both the American and National Football Conferences.\n",
+      "Where the word 'illegal' appears in this rule book, it is an institutional term of art pertaining strictly to actions that violate NFL playing rules. It is not meant to connote illegality under any public law or the rules or regulations of any other organization.\n",
+      "The word 'flagrant,' when used here to describe an action by a player, is meant to indicate that the degree of a violation of the rules-usually a personal foul or  unnecessary roughness-is extremely objectionable, conspicuous, unnecessary, avoidable, or gratuitous. 'Flagrant' in these rules does not necessarily imply malice on the part of the fouling player or an intention to injure an opponent.\n",
+      "Copyright © 2022 by the National Football League. All rights reserved. Printed in the United States of America.\n",
+      "Bottom of the yard line numbers must be 12 yards from the sideline.\n",
+      "Selected 2 contexts\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:06<00:00,  3.12s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-nfl-rulebook-final: Status.SUCCESS\n",
+      "processing chunks that looks like:\n",
+      "Opening Deposit\n",
+      "$100 or more\n",
+      "Interest Rate\n",
+      "This account earns interest at a variable rate. You can find current rate information at bankofamerica.com, by calling the number on your account statement or visiting a financial center.\n",
+      "Monthly\n",
+      "Maintenance\n",
+      "Fee\n",
+      "$25.00 each month. You can avoid the Monthly Maintenance Fee when you meet ONE of the following requirements during each statement cycle:\n",
+      "• Maintain a minimum daily balance of $20,000 or more in your account OR\n",
+      "• Be a member of the Preferred Rewards program. Learn more at bankofamerica.com/preferred-rewards.\n",
+      "ATM fees\n",
+      "Bank of America ATMs\n",
+      "No ATM fee\n",
+      "For deposits, withdrawals, transfers or balance inquiries\n",
+      "Non-Bank of America ATMs\n",
+      "$2.50\n",
+      "In the U.S., plus any fee charged by the ATM's operator\n",
+      "$5.00\n",
+      "Outside the U.S., plus any fee charged by the ATM's operator\n",
+      "Selected 2 contexts\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:08<00:00,  4.05s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BofA_InterestChecking_en_ADA: Status.SUCCESS\n",
+      "processing chunks that looks like:\n",
+      "FDIC\n",
+      "Coverage\n",
+      "This account is insured by the Federal Deposit Insurance Corporation (FDIC) and is backed by the U.S. government. The standard insurance amount is $250,000 per depositor, per insured bank, for each account ownership category.\n",
+      "Monthly Maintenance Fee\n",
+      "$8.00\n",
+      "each month\n",
+      "(We'll waive this fee for the first 6 months.)\n",
+      "You can avoid the Monthly Maintenance Fee when you meet ONE of the following requirements during each statement cycle:\n",
+      "· Maintain a minimum daily balance of $500 or more in your account, OR\n",
+      "· Ask us to link your account to your Bank of America Advantage Relationship Banking ® , Bank of America Advantage  with Tiered Interest Checking or Bank of America Advantage ® ® Regular Checking account (first 4 savings accounts), OR\n",
+      "· An owner of this account is under the age of 25 (fiduciary accounts don't qualify), OR\n",
+      "· Be a member of the Preferred Rewards program. Learn more at bankofamerica.com/preferred-rewards, or visit your local financial center.\n",
+      "Selected 2 contexts\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:06<00:00,  3.01s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Advantag Savings: Status.SUCCESS\n"
      ]
     },
     {
@@ -592,20 +735,20 @@
    "source": [
     "import random #TODO: replace random sampling with subset selection\n",
     "\n",
-    "generated_files = []\n",
-    "\n",
-    "for doc, chunks in dataset.items():\n",
-    "    generate_options.generated_file = AUTHORING_OUTPUT_DIR / f\"qagen-{doc}.json\"\n",
-    "    gen = Generator(generate_options=generate_options)\n",
-    "    print(f\"processing chunks that looks like:\\n{chunks[0].text}\")\n",
-    "    selected_chunks = random.sample(chunks, NUM_CHUNKS_PER_FILE_TO_SELECT_FOR_AUTHORING)\n",
-    "    print(f\"Selected {len(selected_chunks)} contexts\")\n",
-    "\n",
-    "    Path.unlink(generate_options.generated_file, missing_ok=True)\n",
-    "    results = gen.generate_from_chunks(selected_chunks) # automatically saves to file\n",
-    "    generated_files.append(generate_options.generated_file)\n",
-    "\n",
-    "    print(f\"{doc}: {results.status}\")"
+    "for contribution in contributions:\n",
+    "    contribution[\"generated_files\"] = []\n",
+    "    for doc, chunks in contribution[\"dataset\"].items():\n",
+    "        generate_options.generated_file = AUTHORING_OUTPUT_DIR / contribution[\"prefix\"] / f\"qagen-{doc}.json\"\n",
+    "        gen = Generator(generate_options=generate_options)\n",
+    "        print(f\"processing chunks that looks like:\\n{chunks[0].text}\")\n",
+    "        selected_chunks = random.sample(chunks, NUM_CHUNKS_PER_FILE_TO_SELECT_FOR_AUTHORING)\n",
+    "        print(f\"Selected {len(selected_chunks)} contexts\")\n",
+    "    \n",
+    "        Path.unlink(generate_options.generated_file, missing_ok=True)\n",
+    "        results = gen.generate_from_chunks(selected_chunks) # automatically saves to file\n",
+    "        contribution[\"generated_files\"].append(generate_options.generated_file)\n",
+    "    \n",
+    "        print(f\"{doc}: {results.status}\")"
    ]
   },
   {
@@ -618,7 +761,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 33,
    "id": "9df2c533-30d7-4c30-9907-7c5655fd2246",
    "metadata": {},
    "outputs": [
@@ -626,8 +769,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Generated QA pairs for 13 contexts\n",
-      "[{'question': 'What is the mandatory color for the lower portion of game socks and/or leg coverings?', 'answer': 'White'}, {'question': \"What are the color options for a player's uniform, including helmets, jerseys, pants, and game socks and/or leg coverings?\", 'answer': 'Players are permitted to wear only the colors or a combination of those colors established for their NFL club in the League Constitution and Bylaws, with white also being an available color for jerseys and mandatory for the lower portion of game socks and/or leg coverings. Each player on a given team must wear the same colors on his uniform as all other players on his team in the same game.'}, {'question': 'Based on the policy, why is it important for players to present an appearance that is appropriate to representing their individual clubs and the National Football League?', 'answer': 'The policy emphasizes professionalism and representation, suggesting that the appearance of players reflects on both their individual clubs and the league as a whole. Therefore, maintaining an appropriate appearance is important for upholding the image and reputation of both the club and the league.'}]\n"
+      "Generated QA pairs for 6 contexts\n",
+      "[{'question': 'What happens to the injured player at the conclusion of an injury timeout prior to the two-minute warning?', 'answer': 'The injured player must leave the game for the completion of one down. However, they will be permitted to remain in the game if either team calls a charged team timeout, the injury is the result of a foul by an opponent, or the period ends or the two-minute warning occurs before the next snap.'}, {'question': 'What are the conditions under which an injured player can remain in the game during an injury timeout prior to the two-minute warning?', 'answer': 'The injured player can remain in the game if either team calls a charged team timeout, the injury is the result of a foul by an opponent, or the period ends or the two-minute warning occurs before the next snap.'}]\n",
+      "Generated QA pairs for 6 contexts\n",
+      "[{'question': \"How many players were initially on each side of Team A's kicker before the ball was blown off the tee?\", 'answer': \"There were five players on each side of Team A's kicker before the ball was blown off the tee.\"}, {'question': \"What is the ruling for Team A's formation after the ball was blown off the tee and A1 came in as the holder?\", 'answer': 'The ruling is that it is an illegal formation. Team A must have two players outside the yard-line numbers and two players between the inbounds line and the yard-line numbers, other than the holder.'}, {'question': 'Based on the information provided, why was the kick through the end zone considered illegal?', 'answer': 'The kick through the end zone was considered illegal because Team A had an illegal formation at the time of the kick.'}]\n"
      ]
     }
    ],
@@ -636,40 +781,22 @@
     "import yaml\n",
     "from textwrap import wrap\n",
     "\n",
-    "qnas = {}\n",
-    "chunk_id_to_text = {}\n",
-    "for file in generated_files:\n",
-    "    with open(file, \"rt\") as f:\n",
-    "        for line in f.readlines():\n",
-    "            entry = json.loads(line)\n",
-    "            chunk_id = entry['chunk_id']\n",
-    "            if chunk_id not in chunk_id_to_text:\n",
-    "                chunk_id_to_text[chunk_id] = entry['context']\n",
-    "            if chunk_id not in qnas:\n",
-    "                qnas[chunk_id] = []\n",
-    "            qnas[chunk_id].append({'question': entry['question'], 'answer': entry['answer']})\n",
-    "\n",
-    "print(f\"Generated QA pairs for {len(qnas)} contexts\")\n",
-    "print(list(qnas.values())[0])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9b6d6c26-f4d5-420d-ae78-ac28cf39efd3",
-   "metadata": {},
-   "source": [
-    "### Define metadata for qna.yaml"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 54,
-   "id": "c7130e90-2b65-4008-86f7-194da74a9523",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "DOCUMENT_OUTLINE = \"A Probabilistic Inference Approach to Inference-Time Scaling of LLMs using Particle-Based Monte Carlo Methods\"\n",
-    "DOMAIN = \"artificial intelligence\""
+    "for contribution in contributions:\n",
+    "    contribution[\"qnas\"] = {}\n",
+    "    contribution[\"chunk_id_to_text\"] = {}\n",
+    "    for file in contribution[\"generated_files\"]:\n",
+    "        with open(file, \"rt\") as f:\n",
+    "            for line in f.readlines():\n",
+    "                entry = json.loads(line)\n",
+    "                chunk_id = entry['chunk_id']\n",
+    "                if chunk_id not in contribution[\"chunk_id_to_text\"]:\n",
+    "                    contribution[\"chunk_id_to_text\"][chunk_id] = entry['context']\n",
+    "                if chunk_id not in contribution[\"qnas\"]:\n",
+    "                    contribution[\"qnas\"][chunk_id] = []\n",
+    "                contribution[\"qnas\"][chunk_id].append({'question': entry['question'], 'answer': entry['answer']})\n",
+    "    \n",
+    "    print(f\"Generated QA pairs for {len(contribution[\"qnas\"])} contexts\")\n",
+    "    print(list(contribution[\"qnas\"].values())[0])"
    ]
   },
   {
@@ -682,7 +809,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 34,
    "id": "d7f26460-737f-4940-b58a-ef6caea313d3",
    "metadata": {},
    "outputs": [
@@ -690,13 +817,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "qna.yaml saved to: workspaces/default/authoring/qna.yaml\n"
+      "qna.yaml saved to: workspaces/default/authoring/nfl/qna.yaml\n",
+      "qna.yaml saved to: workspaces/default/authoring/finance/qna.yaml\n"
      ]
     }
    ],
    "source": [
-    "qna_output_path = AUTHORING_OUTPUT_DIR / \"qna.yaml\"\n",
-    "\n",
     "# The following creates a data structure for outputting in the expected format for qna.yaml\n",
     "# TODO: extract into utils library\n",
     "\n",
@@ -717,26 +843,29 @@
     "    def increase_indent(self, flow=False, indentless=False):\n",
     "        return super(IndentedDumper, self).increase_indent(flow, False)\n",
     "\n",
-    "data = {'seed_examples': []}\n",
-    "for chunk_id, context in chunk_id_to_text.items():\n",
-    "    data['seed_examples'].append({\n",
-    "        'context': context,\n",
-    "        'questions_and_answers': [\n",
-    "            {\n",
-    "                'question': example['question'],\n",
-    "                'answer': example['answer'],\n",
-    "            } for example in qnas[chunk_id]\n",
-    "        ]\n",
-    "    })\n",
-    "\n",
-    "data['document_outline'] = DOCUMENT_OUTLINE\n",
-    "data['domain'] = DOMAIN\n",
-    "\n",
-    "Path.unlink(qna_output_path, missing_ok=True) # shouldn't be necessary but was. jupyter caching thing?\n",
-    "with open(qna_output_path, 'w') as yaml_file:\n",
-    "    yaml.dump(data, yaml_file, Dumper=IndentedDumper, default_flow_style=False, sort_keys=False, width=80)\n",
-    "\n",
-    "print(f\"qna.yaml saved to: {qna_output_path}\")"
+    "for contribution in contributions:\n",
+    "    qna_output_path = AUTHORING_OUTPUT_DIR / contribution[\"prefix\"] / \"qna.yaml\"\n",
+    "    \n",
+    "    data = {'seed_examples': []}\n",
+    "    for chunk_id, context in contribution[\"chunk_id_to_text\"].items():\n",
+    "        data['seed_examples'].append({\n",
+    "            'context': context,\n",
+    "            'questions_and_answers': [\n",
+    "                {\n",
+    "                    'question': example['question'],\n",
+    "                    'answer': example['answer'],\n",
+    "                } for example in contribution[\"qnas\"][chunk_id]\n",
+    "            ]\n",
+    "        })\n",
+    "    \n",
+    "    data['document_outline'] = contribution[\"summary\"]\n",
+    "    data['domain'] = contribution[\"domain\"]\n",
+    "    \n",
+    "    Path.unlink(qna_output_path, missing_ok=True) # shouldn't be necessary but was. jupyter caching thing?\n",
+    "    with open(qna_output_path, 'w') as yaml_file:\n",
+    "        yaml.dump(data, yaml_file, Dumper=IndentedDumper, default_flow_style=False, sort_keys=False, width=80)\n",
+    "    \n",
+    "    print(f\"qna.yaml saved to: {qna_output_path}\")"
    ]
   },
   {
@@ -749,7 +878,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 37,
    "id": "1293d445-b826-4b92-ad20-9b121ac60e20",
    "metadata": {},
    "outputs": [
@@ -757,197 +886,98 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "========== qna.yaml at workspaces/default/authoring/nfl/qna.yaml ==========\n",
       "seed_examples:\n",
       "  - context: |-\n",
-      "      ARTICLE 1.  GENERAL POLICY. Throughout the game-day period while in view of the stadium and television audience, including during team pregame warm-ups, all players must dress in a professional manner under the uniform standards. The helmet and mandatory padding referenced in Article 3 below are intended to provide reasonable protection to a player while reasonably avoiding risk of injury to other players. The development of Playing Rules should be governed by this Article. Players generally must present an appearance that is appropriate to representing their individual clubs and the National Football League. The term uniform, as used in this policy, applies to every piece of equipment worn by a player, including helmet, shoulder pads, thigh pads, knee pads, and any other item of protective gear, and to every visible item of apparel, including but not limited to pants, jerseys, wristbands, gloves, game socks and/or leg coverings, shoes, visible undergarments, and accessories such as headwear worn under helmets and hand towels. All visible items worn on game day by players must be issued by the club or the League, or, if from outside sources, must have approval in advance by the League office.\n",
-      "      ARTICLE 2.  TEAM COLORS. Pursuant to the official colors established for each NFL club in the League Constitution and Bylaws, playing squads are permitted to wear only those colors or a combination of those colors for helmets, jerseys, pants, and game socks and/or leg coverings; provided that white is also an available color for jerseys and mandatory color for the lower portion of game socks and/or leg coverings. (See 5-4-3-Item 6, 'Game socks and/or leg coverings,' below). Each player on a given team must wear the same colors on his uniform as all other players on his team in the same game. Home clubs shall choose their jersey color (either white or official team color), and visiting clubs must wear the opposite. For preseason, regular season, or postseason\n",
+      "      Note: If  an  attempt  is  made  to  call  a  timeout  in  such  situations,  the  officials  shall  not  grant  a  timeout;  instead,  play  will continue, and a penalty will be called, with customary enforcement. If a timeout is inadvertently granted and charged, the penalty shall also be enforced. See 12-3-1-w.\n",
+      "      ARTICLE 2.  INJURY TIMEOUTS. If an official determines a player to be injured, or if attendants from the bench come on the field to assist an injured player, an injury timeout will be called by the Referee. If the ATC Spotter identifies a player for medical attention, the rules pertaining to Injury Timeouts in Article 3 and Article 4 (c) apply.\n",
+      "      ARTICLE 3.  INJURY TIMEOUTS PRIOR TO TWO-MINUTE WARNING OF EITHER HALF. When an injury timeout is called, the injured player must leave the game for the completion of one down. The player will be permitted to remain in the game if:\n",
+      "      (a) either team calls a charged team timeout;\n",
+      "      (b) the injury is the result of a foul by an opponent; or\n",
+      "      (c) the period ends or the two-minute warning occurs before the next snap.\n",
+      "      At the conclusion of an injury timeout, the game clock will start as if the injury timeout had not occurred. If either team takes, or is charged with, a timeout, the clock will start on the snap.\n",
+      "      ARTICLE 4.  INJURY TIMEOUTS AFTER TWO-MINUTE WARNING OF EITHER HALF. After the two-minute  warning  of  a half, the following shall apply:\n",
       "    questions_and_answers:\n",
       "      - question: |-\n",
-      "          What is the mandatory color for the lower portion of game socks and/or leg\n",
-      "          coverings?\n",
-      "        answer: White\n",
-      "      - question: |-\n",
-      "          What are the color options for a player's uniform, including helmets, jerseys,\n",
-      "          pants, and game socks and/or leg coverings?\n",
+      "          What happens to the injured player at the conclusion of an injury timeout prior\n",
+      "          to the two-minute warning?\n",
       "        answer: |-\n",
-      "          Players are permitted to wear only the colors or a combination of those colors\n",
-      "          established for their NFL club in the League Constitution and Bylaws, with white\n",
-      "          also being an available color for jerseys and mandatory for the lower portion of\n",
-      "          game socks and/or leg coverings. Each player on a given team must wear the same\n",
-      "          colors on his uniform as all other players on his team in the same game.\n",
+      "          The injured player must leave the game for the completion of one down. However,\n",
+      "          they will be permitted to remain in the game if either team calls a charged team\n",
+      "          timeout, the injury is the result of a foul by an opponent, or the period ends\n",
+      "          or the two-minute warning occurs before the next snap.\n",
       "      - question: |-\n",
-      "          Based on the policy, why is it important for players to present an appearance\n",
-      "          that is appropriate to representing their individual clubs and the National\n",
-      "          Football League?\n",
+      "          What are the conditions under which an injured player can remain in the game\n",
+      "          during an injury timeout prior to the two-minute warning?\n",
       "        answer: |-\n",
-      "          The policy emphasizes professionalism and representation, suggesting that the\n",
-      "          appearance of players reflects on both their individual clubs and the league as\n",
-      "          a whole. Therefore, maintaining an appropriate appearance is important for\n",
-      "          upholding the image and reputation of both the club and the league.\n",
+      "          The injured player can remain in the game if either team calls a charged team\n",
+      "          timeout, the injury is the result of a foul by an opponent, or the period ends\n",
+      "          or the two-minute warning occurs before the next snap.\n",
       "  - context: |-\n",
-      "      Third-and-5 on B40. End A2 is illegally chucked out of bounds at the B30, immediately returns inbounds, and is interfered with by B2 at the B25, while the pass is in the air. B2 intercepts the ball and is tackled at the B40.\n",
-      "      Ruling: A's ball, first-and-10 on B25. Since A2 was illegally contacted out of bounds, he is an eligible receiver as soon as he re-establishes, and this is defensive pass interference. Decline the illegal contact penalty. A2 must make an immediate attempt to return inbounds in order to be eligible.\n",
+      "      Second-and-10 on B35. With 12:00 remaining in the fourth quarter, QBA1 rolls out and throws a pass to A2 at the back of the end zone that is ruled incomplete. Team A challenges that the pass was complete, but replays show that A2 only got one foot down inbounds and the call on the field is upheld. While the Referee is making his announcement, a new replay comes up that shows the QB stepping on the sideline at the B40 before releasing the pass. Team B challenges the play.\n",
+      "      Ruling: Reviewable. Both teams can challenge the same play. A's ball third-and-15 on the B40, reset the clock to the time when the QB stepped out of bounds, and start on the snap. A team cannot challenge the same play twice. It is important that all reviewable aspects of a play are confirmed by replay regardless of what is being challenged. Team A is charged with a challenge and a timeout.\n",
       "    questions_and_answers:\n",
-      "      - question: What is the ruling of the play?\n",
-      "        answer: A's ball, first-and-10 on B25.\n",
-      "      - question: What are the key penalties and their outcomes in this play?\n",
+      "      - question: What is the result of the second review?\n",
       "        answer: |-\n",
-      "          There are two penalties in this play: illegal contact and defensive pass\n",
-      "          interference. The illegal contact penalty is declined, and the defensive pass\n",
-      "          interference results in A's ball, first-and-10 on B25.\n",
+      "          The second review shows that the QB stepped on the sideline at the B40 before\n",
+      "          releasing the pass, and the play is ruled incomplete.\n",
+      "      - question: What is the overall result of the two reviews?\n",
+      "        answer: |-\n",
+      "          The first review upheld the call that A2 only got one foot down inbounds, and\n",
+      "          the second review showed that the QB stepped on the sideline before releasing\n",
+      "          the pass, resulting in an incomplete pass.\n",
+      "      - question: |-\n",
+      "          Based on the information provided, why is Team A charged with a challenge and a\n",
+      "          timeout?\n",
+      "        answer: |-\n",
+      "          Team A is charged with a challenge and a timeout because they challenged the\n",
+      "          same play twice, which is against the rules.\n",
       "  - context: |-\n",
-      "      Fourth-and-3 on B20. On a field-goal attempt, center A5 lines up on the end of\n",
-      "      the line in the middle of the field. Holder A2 and kicker A1 line up directly\n",
-      "      behind A5. The rest of the team is lined up at the inbounds line 15 yards away\n",
-      "      from center A5. The ball is snapped by A5 to up-back A4, who is lined up behind\n",
-      "      the rest of the line at the inbounds spot. A5 did not snap the ball through his\n",
-      "      legs. A4 runs to the B5 where he is tackled. Center A5: (a) reported as eligible\n",
-      "      prior to the snap; or (b) A5 did not report as eligible prior to the snap.\n",
+      "      the amount available after transfer.. For international wire transfers, other\n",
+      "      fees may also apply, including those charged by recipient's financial\n",
+      "      institution, foreign taxes, and other fees that are part of the wire transfer\n",
+      "      process. We profit from markups associated with the currency conversion included\n",
+      "      in our exchange rate (determined solely by us). Before sending in foreign\n",
+      "      currency, you should consider factors that impact the total cost or the amount\n",
+      "      available after transfer., 2 = For international wire transfers, other fees may\n",
+      "      also apply, including those charged by recipient's financial institution,\n",
+      "      foreign taxes, and other fees that are part of the wire transfer process. We\n",
+      "      profit from markups associated with the currency conversion included in our\n",
+      "      exchange rate (determined solely by us). Before sending in foreign currency, you\n",
+      "      should consider factors that impact the total cost or the amount available after\n",
+      "      transfer.. Non-Bank of America Teller Withdrawal, 1 = Per transaction, greater\n",
+      "      of $5.00 OR 3% of the amount (maximum $10.00) when you use your ATM or debit\n",
+      "      card, or card number, to make a withdrawal, transfer or payment at another bank\n",
+      "      and it is processed as a cash disbursement.. Non-Bank of America Teller\n",
+      "      Withdrawal, 2 = Per transaction, greater of $5.00 OR 3% of the amount (maximum\n",
+      "      $10.00) when you use your ATM or debit card, or card number, to make a\n",
+      "      withdrawal, transfer or payment at another bank and it is processed as a cash\n",
+      "      disbursement.\n",
       "    questions_and_answers:\n",
-      "      - question: Did center A5 report as eligible prior to the snap?\n",
-      "        answer: No, according to the passage, A5 did not report as eligible prior\n",
-      "          to the snap.\n",
-      "      - question: What is the formation of the team at the time of the snap?\n",
-      "        answer: |-\n",
-      "          At the time of the snap, center A5 is at the end of the line in the middle of\n",
-      "          the field, holder A2 and kicker A1 are directly behind A5, and the rest of the\n",
-      "          team is lined up at the inbounds line 15 yards away from center A5. The ball is\n",
-      "          snapped by A5 to up-back A4, who is lined up behind the rest of the line at the\n",
-      "          inbounds spot.\n",
-      "      - question: Based on the information provided, can we determine if this was\n",
-      "          a legal play?\n",
-      "        answer: |-\n",
-      "          No, the passage does not provide enough information to determine if this was a\n",
-      "          legal play. It only mentions that center A5 did not report as eligible prior to\n",
-      "          the snap, but it does not specify if this is a requirement for the play or if\n",
-      "          any rules were violated.\n",
-      "  - context: |-\n",
-      "      (a) B's ball, first-and-10 on B27. The kick ended behind the line of scrimmage, so there is no 'spot of kick' option.\n",
-      "      (b) B's ball, first-and-10 on B17. The kick ended behind the line of scrimmage, so there is no 'spot of kick' option. Since A2 legally advanced the untouched kick recovered behind the line, his advance is legal, and Team B takes over on downs at the dead ball spot.\n",
-      "      (c) A's ball, first-and-10 on B14. The kick ended behind the line of scrimmage, so there is no 'spot of kick' option. Since A2 legally advanced the untouched kick recovered behind the line, his advance is legal. A2 reached the line to gain, so it is a first down for Team A.\n",
-      "      (d) B's ball, first-and-10 on B30. Illegal forward pass, as the ball has been beyond the line. The penalty is five yards from the previous spot and a loss of down. The kick ended behind the line of scrimmage, so there is no 'spot of kick' option.\n",
-      "      (e) B's ball, first-and-10 on B31. The kick ended behind the line of scrimmage, so there is no 'spot of kick' option. Team B keeps the ball at the dead ball spot.\n",
-      "      Note : Team B does not have the option to take the ball at the spot of the kick if: (1) B touches the ball beyond the line of scrimmage; (2) the kick ends behind the line; or (3) a Team B foul during the play is accepted.\n",
-      "    questions_and_answers:\n",
+      "      - question: What is the maximum amount charged for a non-Bank of America Teller\n",
+      "          Withdrawal?\n",
+      "        answer: $10.00\n",
       "      - question: |-\n",
-      "          What happens if a team recovers an untouched kick behind the line of scrimmage\n",
-      "          and legally advances it?\n",
+      "          What are the different fees associated with international wire transfers and\n",
+      "          non-Bank of America Teller Withdrawals?\n",
       "        answer: |-\n",
-      "          The team that advanced the kick legally takes over on downs at the dead ball\n",
-      "          spot.\n",
+      "          For international wire transfers, fees may include those charged by the\n",
+      "          recipient's financial institution, foreign taxes, and other fees that are part\n",
+      "          of the wire transfer process. We also profit from markups associated with the\n",
+      "          currency conversion. For non-Bank of America Teller Withdrawals, the fee is the\n",
+      "          greater of $5.00 or 3% of the amount, with a maximum of $10.00.\n",
       "      - question: |-\n",
-      "          What are the conditions under which Team B cannot take the ball at the spot of\n",
-      "          the kick?\n",
+      "          Given the fees for non-Bank of America Teller Withdrawals and international wire\n",
+      "          transfers, why might it be more cost-effective to use Bank of America's services\n",
+      "          for international wire transfers?\n",
       "        answer: |-\n",
-      "          Team B cannot take the ball at the spot of the kick if B touches the ball beyond\n",
-      "          the line of scrimmage, the kick ends behind the line, or a Team B foul during\n",
-      "          the play is accepted.\n",
-      "      - question: |-\n",
-      "          If Team B commits an illegal forward pass beyond the line of scrimmage, what is\n",
-      "          the penalty?\n",
-      "        answer: The penalty is five yards from the previous spot and a loss of down.\n",
-      "  - context: |-\n",
-      "      Second-and-10 on A20. A2 takes a handoff and runs to the 50. As he is being\n",
-      "      tackled, he hands the ball to A3 who is running parallel with him. A3 initially\n",
-      "      touches the ball at the 50, but doesn't control it until the B48 ahead of A2. A3\n",
-      "      runs for a touchdown. Ruling: Reviewable. Legal handoff, touchdown. For it to be\n",
-      "      illegal, the player receiving the handoff must be clearly in advance of the\n",
-      "      player making the handoff when he first touches the ball. Only the Replay\n",
-      "      Official can initiate a review of this play.\n",
-      "    questions_and_answers:\n",
-      "      - question: Who can initiate a review of the play?\n",
-      "        answer: Only the Replay Official can initiate a review of this play.\n",
-      "      - question: What was the outcome of the play and what was the ruling on its\n",
-      "          legality?\n",
-      "        answer: |-\n",
-      "          A3 ran for a touchdown and the ruling was that it was a legal handoff and\n",
-      "          touchdown.\n",
-      "      - question: |-\n",
-      "          Based on the information provided, was A3 in advance of A2 when he first touched\n",
-      "          the ball?\n",
-      "        answer: |-\n",
-      "          No, A3 initially touched the ball at the 50, but didn't control it until the B48\n",
-      "          ahead of A2.\n",
-      "  - context: \"\\xB7 Cash, direct deposits, wire transfers: On the day we receive them.\\n\\\n",
-      "      \\xB7 Checks: Usually the next business day, if deposited before the financial\\\n",
-      "      \\ center or ATM cutoff time.\\n\\xB7 Mobile Check Deposit: Usually the next business\\\n",
-      "      \\ day if deposited by applicable cutoff times. Please refer to Deposit Checks\\\n",
-      "      \\ , then Help in the Mobile Banking app for additional details and terms and\\\n",
-      "      \\ conditions.\\n\\xB7 If we place a hold on your deposit, we'll let you know the\\\n",
-      "      \\ hold reason and when your funds will be available. This is typically provided\\\n",
-      "      \\ at the time of deposit but may also be mailed later. Deposits greater than\\\n",
-      "      \\ $5,525 and checks deposited within the first 30 days of account opening may\\\n",
-      "      \\ be held longer.\"\n",
-      "    questions_and_answers:\n",
-      "      - question: What is the usual availability of cash and wire transfers when received?\n",
-      "        answer: On the day they are received.\n",
-      "      - question: What is the usual availability of funds for different types of deposits?\n",
-      "        answer: |-\n",
-      "          Direct deposits and wire transfers are usually available on the day they are\n",
-      "          received, checks are usually available the next business day if deposited before\n",
-      "          the cutoff time, and mobile check deposits are usually available the next\n",
-      "          business day if deposited by applicable cutoff times.\n",
-      "      - question: If a deposit is held, when are the funds typically available?\n",
-      "        answer: |-\n",
-      "          If a deposit is held, the funds will typically be available when the hold is\n",
-      "          released, which is typically communicated at the time of deposit but may also be\n",
-      "          mailed later. Deposits greater than $5,525 and checks deposited within the first\n",
-      "          30 days of account opening may be held longer.\n",
-      "  - context: \"Opening Deposit\\n$100 or more\\nInterest Rate\\nThis account earns interest\\\n",
-      "      \\ at a variable rate. You can find current rate information at bankofamerica.com,\\\n",
-      "      \\ by calling the number on your account statement or visiting a financial center.\\n\\\n",
-      "      Monthly\\nMaintenance\\nFee\\n$25.00 each month. You can avoid the Monthly Maintenance\\\n",
-      "      \\ Fee when you meet ONE of the following requirements during each statement\\\n",
-      "      \\ cycle:\\n\\u2022 Maintain a minimum daily balance of $20,000 or more in your\\\n",
-      "      \\ account OR\\n\\u2022 Be a member of the Preferred Rewards program. Learn more\\\n",
-      "      \\ at bankofamerica.com/preferred-rewards.\\nATM fees\\nBank of America ATMs\\n\\\n",
-      "      No ATM fee\\nFor deposits, withdrawals, transfers or balance inquiries\\nNon-Bank\\\n",
-      "      \\ of America ATMs\\n$2.50\\nIn the U.S., plus any fee charged by the ATM's operator\\n\\\n",
-      "      $5.00\\nOutside the U.S., plus any fee charged by the ATM's operator\"\n",
-      "    questions_and_answers:\n",
-      "      - question: What is the variable interest rate for this account?\n",
-      "        answer: |-\n",
-      "          The text does not provide the variable interest rate for this account. It can be\n",
-      "          found at bankofamerica.com, by calling the number on your account statement or\n",
-      "          visiting a financial center.\n",
-      "      - question: What are the ways to avoid the monthly maintenance fee of $25?\n",
-      "        answer: |-\n",
-      "          The monthly maintenance fee of $25 can be avoided by maintaining a minimum daily\n",
-      "          balance of $20,000 or more in the account or by being a member of the Preferred\n",
-      "          Rewards program.\n",
-      "      - question: |-\n",
-      "          If I have a balance of $20,000 in my account, will I still be charged the ATM\n",
-      "          fee for using a non-Bank of America ATM?\n",
-      "        answer: |-\n",
-      "          No, if you maintain a minimum daily balance of $20,000 or more in your account,\n",
-      "          you will not be charged the ATM fee for using a non-Bank of America ATM.\n",
-      "          However, you may still be charged a fee by the ATM's operator.\n",
-      "  - context: \"\\xB7 To help you avoid fees, we won't authorize ATM withdrawals or everyday\\\n",
-      "      \\ debit card purchases when you don't have enough money in your account at the\\\n",
-      "      \\ time of the transaction.\\n\\xB7 When we determine you don't have enough money\\\n",
-      "      \\ in your account to cover other items such as checks or scheduled payments,\\\n",
-      "      \\ we'll either authorize and pay the item and overdraw your account (an overdraft\\\n",
-      "      \\ item),  or decline or return the item unpaid (a returned item). When 1 this\\\n",
-      "      \\ happens, you may be charged a fee. See details below.\\n\\u2022 We offer two\\\n",
-      "      \\ overdraft setting options for how you want us to process your other transactions.\"\n",
-      "    questions_and_answers:\n",
-      "      - question: |-\n",
-      "          What happens when there is not enough money in the account to cover other items\n",
-      "          like checks or scheduled payments?\n",
-      "        answer: |-\n",
-      "          The bank will either authorize and pay the item and overdraw the account, or\n",
-      "          decline or return the item unpaid.\n",
-      "      - question: |-\n",
-      "          What are the two overdraft setting options the bank offers for processing other\n",
-      "          transactions?\n",
-      "        answer: The bank offers two overdraft setting options for processing other\n",
-      "          transactions.\n",
-      "      - question: |-\n",
-      "          If the bank overdraws an account and charges a fee, why might a customer\n",
-      "          consider changing their overdraft setting option?\n",
-      "        answer: |-\n",
-      "          A customer might consider changing their overdraft setting option to avoid or\n",
-      "          reduce the frequency of overdraft fees.\n",
+      "          Using Bank of America's services for international wire transfers might be more\n",
+      "          cost-effective because, although there may be fees associated with the transfer,\n",
+      "          the bank determines the exchange rate markups solely, potentially offering a\n",
+      "          more favorable rate than other financial institutions. Additionally, there would\n",
+      "          be no fees for using a non-Bank of America ATM or debit card for the transfer.\n",
+      "          However, one should still consider all factors that could impact the total cost\n",
+      "          or the amount available after transfer.\n",
       "  - context: \"Review all the features and benefits of your new account at bankofamerica.com/quickstart\\n\\\n",
       "      For questions, schedule an appointment to visit a financial center at bankofamerica.com/appointments\\n\\\n",
       "      Call us at 800.432.1000\\nAdditional fee waivers may be available to Bank of\\\n",
@@ -974,136 +1004,217 @@
       "          outcome?\n",
       "        answer: The client would learn more about any available fee waivers.\n",
       "  - context: |-\n",
-      "      Additional fees, 1 = Additional fees. Additional fees, 2 = Additional fees.\n",
-      "      Statement copies, 1 = No fee. Statement copies, 2 = Paper copies available upon\n",
-      "      request. Printable statements are available in Online Banking.. Check images, 1\n",
-      "      = No fee. Check images, 2 = Printable check images from the last 18 months are\n",
-      "      available online.. Ordering checks, 1 = Varies. Ordering checks, 2 = No fee on\n",
-      "      standard styles and discounts on certain styles. Card replacement, 1 = No fee.\n",
-      "      Card replacement, 2 = For each ATM or debit card. Card replacement, 1 = $15.00.\n",
-      "      Card replacement, 2 = For rush delivery. Stop payment, 1 = WAIVED $30.00. Stop\n",
-      "      payment, 2 = For each request. Cashier's checks, 1 = $15.00. Cashier's checks, 2\n",
-      "      = For each check. Domestic wire transfers, 1 = WAIVED $15.00. Domestic wire\n",
-      "      transfers, 2 = For each incoming wire transfer. Domestic wire transfers, 1 =\n",
-      "      $30.00. Domestic wire transfers, 2 = For each outgoing wire transfer.\n",
-      "      International wire transfers, 1 = $15.00. International wire transfers, 2 = For\n",
-      "      each incoming wire transfer: If received in a foreign currency, it will be\n",
-      "      converted into U.S. Dollars using the applicable exchange rate determined solely\n",
-      "      by us.. International wire transfers, 1 = No wire fee. International wire\n",
-      "      transfers, 2 = For each outgoing wire transfer sent in foreign currency. Please\n",
-      "      be advised, exchange rate markups will apply. See below.. International wire\n",
-      "      transfers, 1 = $45.00. International wire transfers, 2 = For each outgoing wire\n",
-      "      transfer sent in U.S. Dollars. For international wire transfers, other fees may\n",
+      "      Cash, direct deposits, wire transfers: On the day we receive them.\n",
+      "      Checks: Usually the next business day if deposited before the financial center or ATM cutoff time.\n",
+      "      Mobile Check Deposit: Usually the next business day if deposited by applicable cutoff times. Please refer to Deposit Checks , then Help in the Mobile Banking app for additional details and terms and conditions.\n",
+      "      If we place a hold on your deposit, we'll let you know the hold reason and when your funds will be available. This is typically provided at the time of deposit but may also be mailed later. Deposits greater than $5,525 and checks deposited within the first 30 days of account opening may be held longer.\n",
+      "    questions_and_answers:\n",
+      "      - question: What is the usual availability of cash and wire transfers when received?\n",
+      "        answer: On the day they are received.\n",
+      "      - question: What is the general timeframe for checks to become available after\n",
+      "          deposit?\n",
+      "        answer: |-\n",
+      "          Checks are usually available the next business day if deposited before the\n",
+      "          financial center or ATM cutoff time.\n",
+      "      - question: |-\n",
+      "          If a check is deposited within the first 30 days of account opening and the\n",
+      "          amount is greater than $5,525, will it be held longer?\n",
+      "        answer: |-\n",
+      "          Yes, deposits greater than $5,525 and checks deposited within the first 30 days\n",
+      "          of account opening may be held longer.\n",
+      "  - context: |-\n",
+      "      Non-Bank of America ATMs, No ATM fee = $2.50. Non-Bank of America ATMs, For deposits, withdrawals, transfers or balance inquiries = In the U.S., plus any fee charged by the ATM's operator. Non-Bank of America ATMs, No ATM fee = $5.00. Non-Bank of America ATMs, For deposits, withdrawals, transfers or balance inquiries = Outside the U.S., plus any fee charged by the ATM's operator. Statement copies, No ATM fee = No fee. Statement copies, For deposits, withdrawals, transfers or balance inquiries = Paper copies available upon request. Printable statements are available in Online Banking.. Stop payment fee, No ATM fee = $30.00. Stop payment fee, For deposits, withdrawals, transfers or balance inquiries = For each request; WAIVED for requests on Bill Pay transactions. Cashier's checks, No ATM fee = $15.00. Cashier's checks, For deposits, withdrawals, transfers or balance inquiries = For each check\n",
+      "      of America debit card, and we'll round up your purchases to the nearest dollar amount and transfer the Build your savings automatically when you enroll in our Keep the Change savings program. Simply make everyday purchases with your Bank difference from your checking account to your savings account.\n",
+      "      Please see the Personal Schedule of Fees and Deposit Agreement and Disclosures for your account terms, and information on how to link eligible accounts to avoid the Monthly Maintenance Fee.\n",
+      "    questions_and_answers:\n",
+      "      - question: What is the fee for a cashier's check at a Non-Bank of America ATM?\n",
+      "        answer: $15.00\n",
+      "      - question: |-\n",
+      "          What are the fees for using a Non-Bank of America ATM for various services\n",
+      "          within the U.S. and outside the U.S.?\n",
+      "        answer: |-\n",
+      "          In the U.S., the fee for using a Non-Bank of America ATM for deposits,\n",
+      "          withdrawals, transfers, or balance inquiries is the ATM's operator fee plus\n",
+      "          $2.50. Outside the U.S., the fee for these services is the ATM's operator fee\n",
+      "          plus $5.00.\n",
+      "      - question: |-\n",
+      "          If you enroll in the Keep the Change savings program, how will your purchases be\n",
+      "          handled?\n",
+      "        answer: |-\n",
+      "          Your purchases will be rounded up to the nearest dollar amount and the\n",
+      "          difference will be transferred from your checking account to your savings\n",
+      "          account.\n",
+      "document_outline: Official playing rules of the National Football League 2022\n",
+      "domain: sports\n",
+      "\n",
+      "========== qna.yaml at workspaces/default/authoring/finance/qna.yaml ==========\n",
+      "seed_examples:\n",
+      "  - context: |-\n",
+      "      On A's kickoff from the A35, Team A has five players to the right of the kicker and five players to the left, all legally set. As the kicker approaches the ball, the wind blows the ball off the tee. Team A brings A1, the widest man, from outside the yard-line numbers in to be the holder. This leaves Team A with just one player outside the yard-line numbers on that side. The ball is kicked through the end zone.\n",
+      "      Ruling : B's ball, first-and-10 on B30 or re-kick A30. Illegal formation. Even though the holder counts toward either side for the purpose of five on each side, Team A must still have two players outside the yard-line numbers and two players, (other than the holder), between the inbounds line and the yard-line numbers.\n",
+      "    questions_and_answers:\n",
+      "      - question: |-\n",
+      "          How many players were initially on each side of Team A's kicker before the ball\n",
+      "          was blown off the tee?\n",
+      "        answer: |-\n",
+      "          There were five players on each side of Team A's kicker before the ball was\n",
+      "          blown off the tee.\n",
+      "      - question: |-\n",
+      "          What is the ruling for Team A's formation after the ball was blown off the tee\n",
+      "          and A1 came in as the holder?\n",
+      "        answer: |-\n",
+      "          The ruling is that it is an illegal formation. Team A must have two players\n",
+      "          outside the yard-line numbers and two players between the inbounds line and the\n",
+      "          yard-line numbers, other than the holder.\n",
+      "      - question: |-\n",
+      "          Based on the information provided, why was the kick through the end zone\n",
+      "          considered illegal?\n",
+      "        answer: |-\n",
+      "          The kick through the end zone was considered illegal because Team A had an\n",
+      "          illegal formation at the time of the kick.\n",
+      "  - context: |-\n",
+      "      Second-and-5 on A30. A2 takes a handoff from a shotgun or T-QB and starts to\n",
+      "      sweep around the right end. As he is (a) behind the normal position of the right\n",
+      "      tackle, or (b) behind the normal position of the tight end, he stops and changes\n",
+      "      direction toward the middle of the field. Left tackle A3 sees A2 change\n",
+      "      direction, runs toward him, and forcibly blocks defensive end B2 at the A28 in\n",
+      "      the chest with his head (not UOH), forearm, or shoulder. The block occurs behind\n",
+      "      the normal right guard position and is parallel to the line of scrimmage. A2\n",
+      "      runs to the 50, where he is tackled.\n",
+      "    questions_and_answers:\n",
+      "      - question: Which player forcibly blocks defensive end B2?\n",
+      "        answer: Left tackle A3\n",
+      "      - question: |-\n",
+      "          Based on the information provided, can it be inferred that A2's change of\n",
+      "          direction was a planned play or a spontaneous decision?\n",
+      "        answer: |-\n",
+      "          The text does not provide enough information to definitively answer this\n",
+      "          question. It could be interpreted either way, depending on the context of the\n",
+      "          overall game strategy.\n",
+      "  - context: \"\\xB7 To help you avoid fees, we won't authorize ATM withdrawals or everyday\\\n",
+      "      \\ debit card purchases when you don't have enough money in your account at the\\\n",
+      "      \\ time of the transaction.\\n\\xB7 When we determine you don't have enough money\\\n",
+      "      \\ in your account to cover other items such as checks or scheduled payments,\\\n",
+      "      \\ we'll either authorize and pay the item and overdraw your account (an overdraft\\\n",
+      "      \\ item),  or decline or return the item unpaid (a returned item). When 1 this\\\n",
+      "      \\ happens, you may be charged a fee. See details below.\\n\\u2022 We offer two\\\n",
+      "      \\ overdraft setting options for how you want us to process your other transactions.\"\n",
+      "    questions_and_answers:\n",
+      "      - question: |-\n",
+      "          What happens when there is not enough money in the account to cover other items\n",
+      "          like checks or scheduled payments?\n",
+      "        answer: |-\n",
+      "          The bank will either authorize and pay the item and overdraw the account, or\n",
+      "          decline or return the item unpaid.\n",
+      "      - question: |-\n",
+      "          What are the two overdraft setting options the bank offers for processing other\n",
+      "          transactions?\n",
+      "        answer: The bank offers two overdraft setting options for processing other\n",
+      "          transactions.\n",
+      "      - question: |-\n",
+      "          If the bank overdraws an account and charges a fee, why might a customer\n",
+      "          consider changing their overdraft setting option?\n",
+      "        answer: |-\n",
+      "          A customer might consider changing their overdraft setting option to avoid or\n",
+      "          reduce the frequency of overdraft fees.\n",
+      "  - context: |-\n",
+      "      the amount available after transfer.. For international wire transfers, other\n",
+      "      fees may also apply, including those charged by recipient's financial\n",
+      "      institution, foreign taxes, and other fees that are part of the wire transfer\n",
+      "      process. We profit from markups associated with the currency conversion included\n",
+      "      in our exchange rate (determined solely by us). Before sending in foreign\n",
+      "      currency, you should consider factors that impact the total cost or the amount\n",
+      "      available after transfer., 2 = For international wire transfers, other fees may\n",
       "      also apply, including those charged by recipient's financial institution,\n",
       "      foreign taxes, and other fees that are part of the wire transfer process. We\n",
       "      profit from markups associated with the currency conversion included in our\n",
       "      exchange rate (determined solely by us). Before sending in foreign currency, you\n",
       "      should consider factors that impact the total cost or the amount available after\n",
-      "      transfer., 1 = For international wire transfers, other fees may also apply,\n",
-      "      including those charged by recipient's financial institution, foreign taxes, and\n",
-      "      other fees that are part of the wire transfer process. We profit from markups\n",
-      "      associated with the currency conversion included in our exchange rate\n",
-      "      (determined solely by us). Before sending in foreign currency, you should\n",
-      "      consider factors that impact the total cost or\n",
+      "      transfer.. Non-Bank of America Teller Withdrawal, 1 = Per transaction, greater\n",
+      "      of $5.00 OR 3% of the amount (maximum $10.00) when you use your ATM or debit\n",
+      "      card, or card number, to make a withdrawal, transfer or payment at another bank\n",
+      "      and it is processed as a cash disbursement.. Non-Bank of America Teller\n",
+      "      Withdrawal, 2 = Per transaction, greater of $5.00 OR 3% of the amount (maximum\n",
+      "      $10.00) when you use your ATM or debit card, or card number, to make a\n",
+      "      withdrawal, transfer or payment at another bank and it is processed as a cash\n",
+      "      disbursement.\n",
       "    questions_and_answers:\n",
-      "      - question: What is the fee for ordering checks with standard styles?\n",
-      "        answer: No fee\n",
-      "      - question: What are the fees associated with international wire transfers?\n",
+      "      - question: What is the maximum amount charged for a non-Bank of America Teller\n",
+      "          Withdrawal?\n",
+      "        answer: $10.00\n",
+      "      - question: |-\n",
+      "          What are the different fees associated with international wire transfers and\n",
+      "          non-Bank of America Teller Withdrawals?\n",
       "        answer: |-\n",
-      "          For incoming wire transfers in foreign currency, there is a $15 fee and a\n",
-      "          currency conversion markup. For incoming wire transfers in US dollars, there is\n",
-      "          a $45 fee. For outgoing wire transfers in foreign currency, there is a $15 fee\n",
-      "          and a currency conversion markup. For outgoing wire transfers in US dollars,\n",
-      "          there is a $30 fee. Other fees may also apply, including those charged by the\n",
+      "          For international wire transfers, fees may include those charged by the\n",
       "          recipient's financial institution, foreign taxes, and other fees that are part\n",
-      "          of the wire transfer process.\n",
+      "          of the wire transfer process. We also profit from markups associated with the\n",
+      "          currency conversion. For non-Bank of America Teller Withdrawals, the fee is the\n",
+      "          greater of $5.00 or 3% of the amount, with a maximum of $10.00.\n",
       "      - question: |-\n",
-      "          Considering the information about international wire transfers, why might it be\n",
-      "          more cost-effective to send a wire transfer in a foreign currency rather than in\n",
-      "          US dollars?\n",
+      "          Given the fees for non-Bank of America Teller Withdrawals and international wire\n",
+      "          transfers, why might it be more cost-effective to use Bank of America's services\n",
+      "          for international wire transfers?\n",
       "        answer: |-\n",
-      "          Sending a wire transfer in a foreign currency might be more cost-effective\n",
-      "          because, even though there is a currency conversion markup, the fee for incoming\n",
-      "          wire transfers in foreign currency is lower than the fee for incoming wire\n",
-      "          transfers in US dollars. However, other factors such as fees charged by the\n",
-      "          recipient's financial institution, foreign taxes, and other fees that are part\n",
-      "          of the wire transfer process should also be considered.\n",
+      "          Using Bank of America's services for international wire transfers might be more\n",
+      "          cost-effective because, although there may be fees associated with the transfer,\n",
+      "          the bank determines the exchange rate markups solely, potentially offering a\n",
+      "          more favorable rate than other financial institutions. Additionally, there would\n",
+      "          be no fees for using a non-Bank of America ATM or debit card for the transfer.\n",
+      "          However, one should still consider all factors that could impact the total cost\n",
+      "          or the amount available after transfer.\n",
       "  - context: |-\n",
-      "      Closed-Source LLMs, Method = . Closed-Source LLMs, MATH500 = . Closed-Source\n",
-      "      LLMs, AIME 2024 = . GPT-4o, Method = -. GPT-4o, MATH500 = 76.2. GPT-4o, AIME\n",
-      "      2024 = 13.3. o1-preview, Method = -. o1-preview, MATH500 = 87.0. o1-preview,\n",
-      "      AIME 2024 = 40.0. Claude3.5-Sonnet, Method = -. Claude3.5-Sonnet, MATH500 =\n",
-      "      78.3. Claude3.5-Sonnet, AIME 2024 = 16.0. Open-Source LLMs, Method = . Open-\n",
-      "      Source LLMs, MATH500 = . Open-Source LLMs, AIME 2024 = . Llama-3.1-70B-Instruct,\n",
-      "      Method = -. Llama-3.1-70B-Instruct, MATH500 = 65.7. Llama-3.1-70B-Instruct, AIME\n",
-      "      2024 = 16.6. Qwen2.5-Math-72B-Instruct, Method = -. Qwen2.5-Math-72B-Instruct,\n",
-      "      MATH500 = 82.0. Qwen2.5-Math-72B-Instruct, AIME 2024 = 30.0. Open-Source SLMs,\n",
-      "      Method = . Open-Source SLMs, MATH500 = . Open-Source SLMs, AIME 2024 = .\n",
-      "      Llama-3.2-1B-Instruct, Method = Pass@1. Llama-3.2-1B-Instruct, MATH500 = 26.8.\n",
-      "      Llama-3.2-1B-Instruct, AIME 2024 = 0.0. , Method = BoN. , MATH500 = 46.6. , AIME\n",
-      "      2024 = 3.3. , Method = WBoN. , MATH500 = 47.8. , AIME 2024 = 3.3. , Method =\n",
-      "      DVTS. , MATH500 = 52.8. , AIME 2024 = 6.6. , Method = Ours - PF. , MATH500 =\n",
-      "      59.6. , AIME 2024 = 10.0. Llama-3.1-8B-Instruct, Method = Pass@1.\n",
+      "      We don't charge overdraft fees on this account. To help you avoid overdrawing your account, transactions will be declined and returned unpaid when you don't have enough money in your account.\n",
+      "      If this happens, you won't be charged a bank overdraft fee, but the merchant or third party could charge you a fee. For example, you may be charged a late fee if the payment isn't received on time.\n",
+      "      There may still be times when your account could have a negative balance, but we won't charge an overdraft fee.\n",
       "    questions_and_answers:\n",
-      "      - question: What is the MATH500 score for GPT-4o?\n",
-      "        answer: '76.2'\n",
+      "      - question: Does this account charge overdraft fees?\n",
+      "        answer: No, this account does not charge overdraft fees.\n",
       "      - question: |-\n",
-      "          Which models have a higher AIME 2024 score: GPT-4o, o1-preview,\n",
-      "          Claude3.5-Sonnet, Llama-3.1-70B-Instruct, Qwen2.5-Math-72B-Instruct, or\n",
-      "          Llama-3.2-1B-Instruct?\n",
+      "          What happens when a transaction is made without sufficient funds in this\n",
+      "          account?\n",
       "        answer: |-\n",
-      "          Qwen2.5-Math-72B-Instruct has the highest AIME 2024 score among the mentioned\n",
-      "          models.\n",
+      "          The transaction is declined and returned unpaid, and the merchant or third party\n",
+      "          could charge a fee.\n",
+      "      - question: |-\n",
+      "          If a payment isn't received on time due to a declined transaction, could the\n",
+      "          payee charge a late fee?\n",
+      "        answer: Yes, the payee could charge a late fee.\n",
       "  - context: |-\n",
-      "      Lightman, H., Kosaraju, V., Burda, Y., Edwards, H., Baker, B., Lee, T., Leike, J., Schulman, J., Sutskever, I., and Cobbe, K. Let's verify step by step, 2023b. URL https: //arxiv.org/abs/2305.20050 .\n",
-      "      Loula, J., LeBrun, B., Du, L., Lipkin, B., Pasti, C., Grand, G., Liu, T., Emara, Y., Freedman, M., Eisner, J., Cotterell, R., Mansinghka, V., Lew, A. K., Vieira, T., and O'Donnell, T. J. Syntactic and semantic control of large language models via sequential monte carlo. In The Thirteenth International Conference on Learning Representations , 2025. URL https://openreview.net/ forum?id=xoXn62FzD0 .\n",
-      "      MacKay, D. J. Information theory, inference and learning algorithms . Cambridge university press, 2003.\n",
-      "      Moral, P. D. Sequential Monte Carlo Methods for Dynamic Systems: Journal of the American Statistical Association: Vol 93, No 443. https://www.tandfonline.com/doi/abs/10.1080/01621459.1998.10473765, 1997.\n",
-      "      Murphy, K. P. Machine learning: a probabilistic perspective . MIT press, 2012.\n",
+      "      Non-Bank of America ATMs, No ATM fee = $2.50. Non-Bank of America ATMs, For deposits, withdrawals, transfers or balance inquiries = In the U.S., plus any fee charged by the ATM's operator. Non-Bank of America ATMs, No ATM fee = $5.00. Non-Bank of America ATMs, For deposits, withdrawals, transfers or balance inquiries = Outside the U.S., plus any fee charged by the ATM's operator. Statement copies, No ATM fee = No fee. Statement copies, For deposits, withdrawals, transfers or balance inquiries = Paper copies available upon request. Printable statements are available in Online Banking.. Stop payment fee, No ATM fee = $30.00. Stop payment fee, For deposits, withdrawals, transfers or balance inquiries = For each request; WAIVED for requests on Bill Pay transactions. Cashier's checks, No ATM fee = $15.00. Cashier's checks, For deposits, withdrawals, transfers or balance inquiries = For each check\n",
+      "      of America debit card, and we'll round up your purchases to the nearest dollar amount and transfer the Build your savings automatically when you enroll in our Keep the Change savings program. Simply make everyday purchases with your Bank difference from your checking account to your savings account.\n",
+      "      Please see the Personal Schedule of Fees and Deposit Agreement and Disclosures for your account terms, and information on how to link eligible accounts to avoid the Monthly Maintenance Fee.\n",
       "    questions_and_answers:\n",
+      "      - question: What is the fee for a cashier's check at a Non-Bank of America ATM?\n",
+      "        answer: $15.00\n",
       "      - question: |-\n",
-      "          Who is one of the authors of the paper 'Syntactic and semantic control of large\n",
-      "          language models via sequential monte carlo'?\n",
-      "        answer: Loula, J.\n",
-      "      - question: |-\n",
-      "          If a language model is trained on a large corpus of text, could it be said to\n",
-      "          have 'learned' the statistics of the language? Why or why not?\n",
+      "          What are the fees for using a Non-Bank of America ATM for various services\n",
+      "          within the U.S. and outside the U.S.?\n",
       "        answer: |-\n",
-      "          Yes, according to the probabilistic perspective of machine learning, a language\n",
-      "          model can be seen as having 'learned' the statistics of the language, as it\n",
-      "          learns the probability distribution of the next word given the previous words.\n",
-      "          This is evident in the 'Machine learning: a probabilistic perspective' book by\n",
-      "          Kevin P. Murphy.\n",
-      "  - context: |-\n",
-      "      3. We study ways to use PRMs and propose a more robust and performant way to obtain rewards for partial answers which we refer to as model-based aggregation.\n",
-      "      4. We demonstrate that the proposed methods have 416x faster scaling speed than previous methods based on a search formulation on the MATH500 and AIME 2024 datasets, with small language models in the Llama and Qwen families. We show that PF can scale Qwen2.5-Math-1.5B-Instruct to surpasses GPT-4o accuracy with only a budget of 4 and scale Qwen2.5Math-7B-Instruct to o1 accuracy with a budget of 32.\n",
-      "    questions_and_answers:\n",
+      "          In the U.S., the fee for using a Non-Bank of America ATM for deposits,\n",
+      "          withdrawals, transfers, or balance inquiries is the ATM's operator fee plus\n",
+      "          $2.50. Outside the U.S., the fee for these services is the ATM's operator fee\n",
+      "          plus $5.00.\n",
       "      - question: |-\n",
-      "          How many times faster is the scaling speed of the proposed methods compared to\n",
-      "          previous methods?\n",
-      "        answer: 416x\n",
-      "      - question: |-\n",
-      "          What are the two datasets used to demonstrate the performance of the proposed\n",
-      "          methods and what are the two families of language models used?\n",
+      "          If you enroll in the Keep the Change savings program, how will your purchases be\n",
+      "          handled?\n",
       "        answer: |-\n",
-      "          The two datasets used are MATH500 and AIME 2024, and the two families of\n",
-      "          language models used are Llama and Qwen.\n",
-      "      - question: |-\n",
-      "          Based on the provided context, if you were to scale Qwen2.5-Math-1.5B-Instruct\n",
-      "          to surpass GPT-4's accuracy with the lowest possible budget, what would that\n",
-      "          budget be?\n",
-      "        answer: The budget would be 4.\n",
-      "document_outline: |-\n",
-      "  A Probabilistic Inference Approach to Inference-Time Scaling of LLMs using\n",
-      "  Particle-Based Monte Carlo Methods\n",
-      "domain: artificial intelligence\n",
+      "          Your purchases will be rounded up to the nearest dollar amount and the\n",
+      "          difference will be transferred from your checking account to your savings\n",
+      "          account.\n",
+      "document_outline: Account information for a specific bank\n",
+      "domain: banking\n",
       "\n"
      ]
     }
    ],
    "source": [
-    "with open(qna_output_path) as yaml_file:\n",
-    "    print(yaml_file.read())"
+    "for contribution in contributions:\n",
+    "    qna_output_path = AUTHORING_OUTPUT_DIR / contribution[\"prefix\"] / \"qna.yaml\"\n",
+    "\n",
+    "    with open(qna_output_path) as yaml_file:\n",
+    "        print(f\"========= qna.yaml at {qna_output_path} ==========\")\n",
+    "        print(yaml_file.read())\n"
    ]
   },
   {
@@ -1132,7 +1243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 38,
    "id": "e2c6e31b-e8a9-406c-b2dc-27433c8fd8ec",
    "metadata": {},
    "outputs": [
@@ -1153,14 +1264,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 47,
    "id": "ab2c9ed2-8ba8-4959-8e01-81625b81d286",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "31028b6a6e894b55bdd91b429008b591",
+       "model_id": "e3ee0f8d1c89435e927863ba0ffa5923",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1174,7 +1285,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "412be6db8f3b4d259bdd6ed8f9314bbd",
+       "model_id": "0b69647ea3d241a985a926b371241210",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1188,7 +1299,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "54e7f91dc8454798bfc61d605a62703a",
+       "model_id": "a54a09d2748d4a01b5a57fda6344857a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1202,7 +1313,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "388343b9ee474bccb65cdb92b016d4fd",
+       "model_id": "b2f6b9b7954b4b66abac7e8b385c97d3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1216,7 +1327,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "33638125f9bb48f39a92e66b80d244bf",
+       "model_id": "b86ffea597dc4078b4264d032def50ea",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1230,7 +1341,231 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7fd66034f06d408a897b5d494f2f67c8",
+       "model_id": "5934aacd5ebc4898a4e1c7949b9894a4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/8990 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9ac6364734404a42a42ba953149edc7b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Filter:   0%|          | 0/8990 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7fd4213d07d6458595636d4a3c3d1189",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3c386876528d43baad39def1c1ebf488",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "88348c0f21fe43eb83e2c1953aa54c7d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fa7363d80f5b423e8cd8304547fabafd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8e555e8db38541fda4b5481ecd356f1a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "efcce14d53f3457b9459e64c4549dbee",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/50 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "702b73ba86f845c280af16188d71f2b6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Filter:   0%|          | 0/50 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6af9b75043be419787fcf9b20be84e5b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "020f450c181946aa871170b8c3ccb951",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "52f50911b9e64f8fabe8aa3c688c10ac",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "45413ce86ec1451d9a2be28c94d28555",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "594299e41ccf4f5a91a02131b3f72d0e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "61b518e7616d4ebe8ecc3daa3725178c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/25 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8a3e43b437204f70bb0a8eb63bee9c17",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Filter:   0%|          | 0/25 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b71da1ee64734d07be712547d1bffadc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1244,7 +1579,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "922a16c14b1f4079963e90924419b301",
+       "model_id": "e9619323ce994418a9619723773b05bf",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1258,7 +1593,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8bc2d4695b7146dc9595ce1a595930d7",
+       "model_id": "dd4c107d13f245f3a1be229c65a06531",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1272,7 +1607,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c2222bfef0734126939deb3b9811f227",
+       "model_id": "5f546b7133c843a5a6698aac7211b144",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1286,7 +1621,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f946dae206564cf985ca682f8c76b103",
+       "model_id": "86b226be63c544b5ac18d962bba8a21e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1300,12 +1635,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "de809767e5754a87aacf4d12211d2086",
+       "model_id": "8139b4f2aadc44aeb8d485d023357569",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Map:   0%|          | 0/17980 [00:00<?, ? examples/s]"
+       "Map:   0%|          | 0/8990 [00:00<?, ? examples/s]"
       ]
      },
      "metadata": {},
@@ -1314,12 +1649,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c35f364424c54c5b97b0086c0c8a358f",
+       "model_id": "a0b5a1c3923f492f827202a38761d32b",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Filter:   0%|          | 0/17980 [00:00<?, ? examples/s]"
+       "Filter:   0%|          | 0/8990 [00:00<?, ? examples/s]"
       ]
      },
      "metadata": {},
@@ -1328,7 +1663,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "18f604fd38eb4212ab3679be71c15ebe",
+       "model_id": "7913d0b16534410880b700664c31e1df",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1342,7 +1677,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d8461ee8d54e456b83365ef02bb3d1a6",
+       "model_id": "1f4920eacce04cc49730fbc02c32b993",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1356,7 +1691,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fcc7688505864e59ac9cb62a6606811b",
+       "model_id": "6178b789c0474c948c891ea5e3006719",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1370,7 +1705,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c2ac4b36c760468c9d56816befa89ee3",
+       "model_id": "16a4e0ce42ec49529ba6d0ee904e854e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1384,7 +1719,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "66c9085ac2ae4ca2b9ed499230d3a520",
+       "model_id": "b44d89b157e84f5881d0c0658ecff86b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1398,12 +1733,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8aa1805692424d138c6b4e31f3c0b9bc",
+       "model_id": "4d4f24315dac4cdd9e99722f826c3dae",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+       "Map:   0%|          | 0/50 [00:00<?, ? examples/s]"
       ]
      },
      "metadata": {},
@@ -1412,12 +1747,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6ae5908940d54fa8a7ffd79080e14057",
+       "model_id": "63ab41e4ab964457a5cd05de412f1502",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+       "Filter:   0%|          | 0/50 [00:00<?, ? examples/s]"
       ]
      },
      "metadata": {},
@@ -1426,12 +1761,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "01f80bb4ddec41da9ba2377f0ca724a0",
+       "model_id": "26d64b525680413ca786217d09ced396",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
       ]
      },
      "metadata": {},
@@ -1440,12 +1775,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "615184103ca2452b844bdd7058cf74d1",
+       "model_id": "65ad5a34887446c6889ab6457dbf6116",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
       ]
      },
      "metadata": {},
@@ -1454,12 +1789,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "46bd1643e1dc42cbbceb1e40782bec73",
+       "model_id": "a07ec71549fd4e64b180a2c6b673e175",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
       ]
      },
      "metadata": {},
@@ -1468,12 +1803,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "18813affd53f4f44961bacea83d577ad",
+       "model_id": "0474ba5867a842d98ed30b9d396e0539",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Map:   0%|          | 0/100 [00:00<?, ? examples/s]"
+       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
       ]
      },
      "metadata": {},
@@ -1482,12 +1817,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "709446274b054d488d824f061f451d64",
+       "model_id": "115d5a63986a48e0a274a350668c01c9",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Filter:   0%|          | 0/100 [00:00<?, ? examples/s]"
+       "Map:   0%|          | 0/5 [00:00<?, ? examples/s]"
       ]
      },
      "metadata": {},
@@ -1496,12 +1831,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0dffa1a44904499198816aea085755c0",
+       "model_id": "bc02423dca15437b94d739a84680589c",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
+       "Map:   0%|          | 0/25 [00:00<?, ? examples/s]"
       ]
      },
      "metadata": {},
@@ -1510,12 +1845,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f2a538c0f64240faab131dc0bffdaf23",
+       "model_id": "efd64c3801f44885ab625978fa8dd252",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
+       "Filter:   0%|          | 0/25 [00:00<?, ? examples/s]"
       ]
      },
      "metadata": {},
@@ -1524,152 +1859,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7c9fb179536c483ca346aed2b7d06048",
+       "model_id": "89bc5361ddc94ca887ae1969ee52659d",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "efe4f3e4db40492b8107ca012d2170b6",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f2244a016bfb4e93bd625894b88e91ae",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1c109b96f4414670b1427761182f1faa",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8f6da7ff38f045419dc6213f6f1ff2ce",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "309b9ffca00f4371b015dad9757f9005",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "287e2af7ed854ac1bbdbd828f1a3fd87",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e76e59d35c194112a695449960a7a227",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2b2917e685e54e42a1df162c4d26bb4d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Map:   0%|          | 0/520 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "11c2b9cf31304be0a78bb83ccef412f7",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Filter:   0%|          | 0/520 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dedfc205063a4f748d2f003d549db666",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Creating json from Arrow format:   0%|          | 0/17 [00:00<?, ?ba/s]"
+       "Creating json from Arrow format:   0%|          | 0/16 [00:00<?, ?ba/s]"
       ]
      },
      "metadata": {},
@@ -1679,19 +1874,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Seed data contains 18600 rows\n",
+      "Seed data contains 18130 rows\n",
       "Results saved to: workspaces/default/sdg/seed_data.jsonl\n"
      ]
     }
    ],
    "source": [
-    "from utils.create_seed_dataset import get_seed_dataset\n",
+    "from utils.create_seed_dataset import get_seed_dataset, safe_concatenate_datasets\n",
     "\n",
-    "seed_data = get_seed_dataset(CHUNKING_OUTPUT_DIR, AUTHORING_OUTPUT_DIR)\n",
+    "contribution_datasets = []\n",
+    "for contribution in contributions:\n",
+    "    chunks_dir = Path(CHUNKING_OUTPUT_DIR / contribution[\"prefix\"])\n",
+    "    qna_dir = Path(AUTHORING_OUTPUT_DIR / contribution[\"prefix\"])\n",
+    "    seed_data = get_seed_dataset(chunks_dir, qna_dir)\n",
+    "    contribution_datasets.append(seed_data)\n",
+    "\n",
+    "final_seed_data = safe_concatenate_datasets(contribution_datasets)\n",
     "output_path = f'{SDG_OUTPUT_DIR}/seed_data.jsonl'\n",
-    "seed_data.to_json(output_path, orient='records', lines=True)\n",
+    "final_seed_data.to_json(output_path, orient='records', lines=True)\n",
     "\n",
-    "print(f\"Seed data contains {seed_data.data.num_rows} rows\")\n",
+    "print(f\"Seed data contains {final_seed_data.data.num_rows} rows\")\n",
     "print(f\"Results saved to: {output_path}\")"
    ]
   },
@@ -1705,7 +1907,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 48,
    "id": "a6936825-31c1-4b46-a1af-2fb46f50158d",
    "metadata": {},
    "outputs": [
@@ -1726,29 +1928,24 @@
       "icl_response_3: string\n",
       "document: string\n",
       "----\n",
-      "document_outline: [[\"A Probabilistic Inference Approach to Inference-Time Scaling of LLMs using\n",
-      "Particle-Based Monte Carlo Methods\"]]\n",
+      "document_outline: [[\"Account information for a specific bank\"]]\n",
       "document_title: [[\"2022-nfl-rulebook-final\"]]\n",
-      "domain: [[\"artificial intelligence\"]]\n",
-      "icl_document: [[\"ARTICLE 1.  GENERAL POLICY. Throughout the game-day period while in view of the stadium and television audience, including during team pregame warm-ups, all players must dress in a professional manner under the uniform standards. The helmet and mandatory padding referenced in Article 3 below are intended to provide reasonable protection to a player while reasonably avoiding risk of injury to other players. The development of Playing Rules should be governed by this Article. Players generally must present an appearance that is appropriate to representing their individual clubs and the National Football League. The term uniform, as used in this policy, applies to every piece of equipment worn by a player, including helmet, shoulder pads, thigh pads, knee pads, and any other item of protective gear, and to every visible item of apparel, including but not limited to pants, jerseys, wristbands, gloves, game socks and/or leg coverings, shoes, visible undergarments, and accessories such as headwear worn under helmets and hand towels. All visible items worn on game day by players must be issued by the club or the League, or, if from outside sources, must have approval in advance by the League office.\n",
-      "ARTICLE 2.  TEAM COLORS. Pursuant to the official colors established for each NFL club in the League Constitution and Bylaws, playing squads are permitted to wear only those colors or a combination of those colors for helmets, jerseys, pants, and game socks and/or leg coverings; provided that white is also an available color for jerseys and mandatory color for the lower portion of game socks and/or leg coverings. (See 5-4-3-Item 6, 'Game socks and/or leg coverings,' below). Each player on a given team must wear the same colors on his uniform as all other players on his team in the same game. Home clubs shall choose their jersey color (either white or official team color), and visiting clubs must wear the opposite. For preseason, regular season, or postseason\"]]\n",
-      "icl_query_1: [[\"What is the mandatory color for the lower portion of game socks and/or leg\n",
-      "coverings?\"]]\n",
-      "icl_response_1: [[\"White\"]]\n",
-      "icl_query_2: [[\"What are the color options for a player's uniform, including helmets, jerseys,\n",
-      "pants, and game socks and/or leg coverings?\"]]\n",
-      "icl_response_2: [[\"Players are permitted to wear only the colors or a combination of those colors\n",
-      "established for their NFL club in the League Constitution and Bylaws, with white\n",
-      "also being an available color for jerseys and mandatory for the lower portion of\n",
-      "game socks and/or leg coverings. Each player on a given team must wear the same\n",
-      "colors on his uniform as all other players on his team in the same game.\"]]\n",
-      "icl_query_3: [[\"Based on the policy, why is it important for players to present an appearance\n",
-      "that is appropriate to representing their individual clubs and the National\n",
-      "Football League?\"]]\n",
-      "icl_response_3: [[\"The policy emphasizes professionalism and representation, suggesting that the\n",
-      "appearance of players reflects on both their individual clubs and the league as\n",
-      "a whole. Therefore, maintaining an appropriate appearance is important for\n",
-      "upholding the image and reputation of both the club and the league.\"]]\n",
+      "domain: [[\"banking\"]]\n",
+      "icl_document: [[\"On A's kickoff from the A35, Team A has five players to the right of the kicker and five players to the left, all legally set. As the kicker approaches the ball, the wind blows the ball off the tee. Team A brings A1, the widest man, from outside the yard-line numbers in to be the holder. This leaves Team A with just one player outside the yard-line numbers on that side. The ball is kicked through the end zone.\n",
+      "Ruling : B's ball, first-and-10 on B30 or re-kick A30. Illegal formation. Even though the holder counts toward either side for the purpose of five on each side, Team A must still have two players outside the yard-line numbers and two players, (other than the holder), between the inbounds line and the yard-line numbers.\"]]\n",
+      "icl_query_1: [[\"How many players were initially on each side of Team A's kicker before the ball\n",
+      "was blown off the tee?\"]]\n",
+      "icl_response_1: [[\"There were five players on each side of Team A's kicker before the ball was\n",
+      "blown off the tee.\"]]\n",
+      "icl_query_2: [[\"What is the ruling for Team A's formation after the ball was blown off the tee\n",
+      "and A1 came in as the holder?\"]]\n",
+      "icl_response_2: [[\"The ruling is that it is an illegal formation. Team A must have two players\n",
+      "outside the yard-line numbers and two players between the inbounds line and the\n",
+      "yard-line numbers, other than the holder.\"]]\n",
+      "icl_query_3: [[\"Based on the information provided, why was the kick through the end zone\n",
+      "considered illegal?\"]]\n",
+      "icl_response_3: [[\"The kick through the end zone was considered illegal because Team A had an\n",
+      "illegal formation at the time of the kick.\"]]\n",
       "...\n"
      ]
     }

--- a/notebooks/instructlab-knowledge/instructlab-knowledge.ipynb
+++ b/notebooks/instructlab-knowledge/instructlab-knowledge.ipynb
@@ -13,6 +13,7 @@
     "\n",
     "**NOTE**: Starting the notebook using Python 3.11 is recommended. Python 3.12 or later are not yet supported. \n",
     "\n",
+    "1. [Data Gathering](#Data-Gathering)\n",
     "1. [Document Conversion](#Document-Conversion)\n",
     "1. [Chunking](#Chunking)\n",
     "1. [Authoring](#Authoring)\n",
@@ -23,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "0acd026f-65bd-4393-bb40-f8aa8bd6828b",
    "metadata": {},
    "outputs": [],
@@ -38,7 +39,6 @@
     "WORKSPACE_DIR = WORKSPACE_ROOT / WORKSPACE_NAME\n",
     "WORKSPACE_DIR.mkdir(exist_ok=True)\n",
     "\n",
-    "SOURCE_DOCUMENT = None # to process a specific document, set its path here; otherwise, the entire source documents repository will be used\n",
     "SOURCE_DOCUMENT_DIR = WORKSPACE_DIR / \"source_documents\"\n",
     "SOURCE_DOCUMENT_DIR.mkdir(parents=True, exist_ok=True)\n",
     "\n",
@@ -51,12 +51,6 @@
     "AUTHORING_OUTPUT_DIR = WORKSPACE_DIR / \"authoring\"\n",
     "AUTHORING_OUTPUT_DIR.mkdir(exist_ok=True)\n",
     "\n",
-    "SEED_EXAMPLE_INPUT_DIR = WORKSPACE_DIR / \"sdg_inputs\"\n",
-    "SEED_EXAMPLE_INPUT_DIR.mkdir(exist_ok=True)\n",
-    "\n",
-    "SEED_EXAMPLE_OUTPUT_DIR = WORKSPACE_DIR / \"seed_examples\"\n",
-    "SEED_EXAMPLE_OUTPUT_DIR.mkdir(exist_ok=True)\n",
-    "\n",
     "SDG_OUTPUT_DIR = WORKSPACE_DIR / \"sdg\"\n",
     "SDG_OUTPUT_DIR.mkdir(exist_ok=True)"
    ]
@@ -66,6 +60,35 @@
    "id": "344b7ac5-fc2a-40a8-8e1f-e8dd8b1153e7",
    "metadata": {},
    "source": [
+    "## Data Gathering\n",
+    "\n",
+    "Ensure the necessary PDF files are in `SOURCE_DOCUMENT_DIR`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "26501e2f-7215-441f-9efa-075f87024893",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Files to convert: [PosixPath('workspaces/default/source_documents/2022-nfl-rulebook-final.pdf'), PosixPath('workspaces/default/source_documents/BofA_InterestChecking_en_ADA.pdf'), PosixPath('workspaces/default/source_documents/2502.01618v3.pdf')]\n"
+     ]
+    }
+   ],
+   "source": [
+    "files = list(SOURCE_DOCUMENT_DIR.glob(\"*.pdf\"))\n",
+    "print(f\"Files to convert: {files}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a4904e6-8e12-4473-8301-cba90e61bd8b",
+   "metadata": {},
+   "source": [
     "## Document Conversion\n",
     "\n",
     "This notebook uses [Docling](https://github.com/docling-project/docling) to convert any type of document into a Docling Document. A Docling Document is the representation of the document after conversion that can be exported as JSON. The JSON output of this notebook can then be used in others such as one that uses Docling's chunking methods."
@@ -73,31 +96,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "b91d4b2e-19cd-46e7-a912-ba9b2904c7cd",
    "metadata": {},
    "outputs": [],
    "source": [
     "!pip install -qq docling"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3f3804ef-4961-44b1-91c9-62929f422702",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "files = []\n",
-    "\n",
-    "if SOURCE_DOCUMENT:\n",
-    "    files.append(Path(SOURCE_DOCUMENT))\n",
-    "else:\n",
-    "    print(\"***** WARNING! Only one file at a time is supported at this time.\")\n",
-    "    files = list(SOURCE_DOCUMENT_DIR.rglob(\"*.pdf\"))\n",
-    "    print(f\"***** Using {files[0]})\")\n",
-    "\n",
-    "print(f\"Files to convert: {files}\")"
    ]
   },
   {
@@ -114,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "157c5e02-edd1-44f6-b20f-f6b4bda1aae7",
    "metadata": {},
    "outputs": [],
@@ -144,10 +148,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "a200039c-b8b2-4087-88ba-7bfb0e393cc9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/amaredia/dev/examples/notebooks/instructlab-knowledge/venv/lib/python3.12/site-packages/torch/utils/data/dataloader.py:683: UserWarning: 'pin_memory' argument is set as true but not supported on MPS now, then device pinned memory won't be used.\n",
+      "  warnings.warn(warn_msg)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Path of JSON output is: /Users/amaredia/dev/examples/notebooks/instructlab-knowledge/workspaces/default/conversion/2022-nfl-rulebook-final.json\n",
+      "Path of JSON output is: /Users/amaredia/dev/examples/notebooks/instructlab-knowledge/workspaces/default/conversion/BofA_InterestChecking_en_ADA.json\n",
+      "Path of JSON output is: /Users/amaredia/dev/examples/notebooks/instructlab-knowledge/workspaces/default/conversion/2502.01618v3.json\n"
+     ]
+    }
+   ],
    "source": [
     "import json\n",
     "\n",
@@ -195,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "50df9d91-add4-46a1-a69d-0f7f9f69542e",
    "metadata": {},
    "outputs": [],
@@ -232,17 +254,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "db983c05-4aa6-4261-9283-2adab69bfbd3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Token indices sequence length is longer than the specified maximum sequence length for this model (583 > 512). Running this sequence through the model will result in indexing errors\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracted 1798 chunks from 2022-nfl-rulebook-final\n",
+      "Extracted 10 chunks from BofA_InterestChecking_en_ADA\n",
+      "Extracted 52 chunks from 2502.01618v3\n"
+     ]
+    }
+   ],
    "source": [
     "all_chunks = []\n",
     "docs = []\n",
     "for file in json_files:\n",
     "    # reconvert the docling JSON for chunking\n",
     "    doc = DocumentConverter().convert(source=file)\n",
-    "    docs.append(doc)\n",
     "    \n",
     "    chunk_iter = chunker.chunk(dl_doc=doc.document)\n",
     "    chunk_objs = list(chunk_iter)\n",
@@ -251,8 +289,11 @@
     "    print(f\"Extracted {len(chunks)} chunks from {doc.document.name}\")\n",
     "    \n",
     "    for chunk in chunks:\n",
-    "        c = dict(chunk=chunk, file=file.stem)\n",
+    "        c = dict(chunk=chunk, file=doc.document.name)\n",
     "        all_chunks.append(c)\n",
+    "    \n",
+    "    docs.append(dict(chunk_objs=chunk_objs,file=doc.document.name))\n",
+    "\n",
     "\n",
     "# TODO: support multiple files save all chunks to single file for review"
    ]
@@ -269,13 +310,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "4fdf34c7-9829-43d2-bf9f-7d1d55bb6a4c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022 OFFICIAL PLAYING RULES OF THE NATIONAL FOOTBALL LEAGUE\n",
+      "Roger Goodell, Commissioner\n"
+     ]
+    }
+   ],
    "source": [
-    "#print(all_chunks)\n",
-    "print(chunks[0])"
+    "print(all_chunks[0][\"chunk\"])"
    ]
   },
   {
@@ -290,7 +339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "6e70d576-a2bc-4274-b660-1cbe051968b1",
    "metadata": {},
    "outputs": [],
@@ -312,10 +361,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "86c48e52-cda7-48ac-84dc-0b844aed5f98",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
+     ]
+    }
+   ],
    "source": [
     "!pip install -qq docling-sdg\n",
     "\n",
@@ -325,10 +385,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "2a165c38-843b-4c89-a8ad-6195b998e284",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chunking and filtering document 2022-nfl-rulebook-final\n",
+      "Created dataset 2022-nfl-rulebook-final with 720 QA chunks\n",
+      "Chunking and filtering document BofA_InterestChecking_en_ADA\n",
+      "Created dataset BofA_InterestChecking_en_ADA with 8 QA chunks\n",
+      "Chunking and filtering document 2502.01618v3\n",
+      "Created dataset 2502.01618v3 with 45 QA chunks\n"
+     ]
+    }
+   ],
    "source": [
     "from docling_sdg.qa.utils import get_qa_chunks\n",
     "\n",
@@ -338,13 +411,13 @@
     "\n",
     "dataset = {}\n",
     "for doc in docs:\n",
-    "    print(f\"Chunking and filtering document {doc.document.name}\")\n",
+    "    print(f\"Chunking and filtering document {doc[\"file\"]}\")\n",
     "    \n",
-    "    # get_qa_chunks expects a list[DocChunk] which we already have from chunk_objs in the chunking section\n",
-    "    qa_chunks = list(get_qa_chunks(doc.document.name, chunk_objs, filters)) #TODO: decouple reference to chunk_objs from above)\n",
-    "    dataset[doc.document.name] = qa_chunks\n",
+    "    # get_qa_chunks expects a list[DocChunk] which we already have from doc[\"chunk_objs\"] in the chunking section\n",
+    "    qa_chunks = list(get_qa_chunks(doc[\"file\"], doc[\"chunk_objs\"], filters)) #TODO: decouple reference to chunk_objs from above)\n",
+    "    dataset[doc[\"file\"]] = qa_chunks\n",
     "    \n",
-    "    print(f\"Created dataset {doc.document.name} with {len(qa_chunks)} QA chunks\")"
+    "    print(f\"Created dataset {doc[\"file\"]} with {len(qa_chunks)} QA chunks\")"
    ]
   },
   {
@@ -363,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "874d4de8",
    "metadata": {
     "tags": [
@@ -379,7 +452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "b702267e-f550-4bc2-bce4-c0fcecbbd292",
    "metadata": {},
    "outputs": [],
@@ -405,12 +478,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 52,
    "id": "f1197d4e-8354-45e3-9ec9-85c78ba36548",
    "metadata": {},
    "outputs": [],
    "source": [
-    "NUM_CHUNKS_TO_SELECT_FOR_AUTHORING = 5"
+    "NUM_CHUNKS_PER_FILE_TO_SELECT_FOR_AUTHORING = 2"
    ]
   },
   {
@@ -423,34 +496,117 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 53,
    "id": "e57edff5-9a13-47fb-9248-9140ae5baaca",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "processing chunks that looks like:\n",
+      "This edition of the Official Playing Rules of the  National Football League  contains all current rules governing the playing of professional football that are in effect for the 2022 NFL season. Member clubs of the League may amend the rules from time to time, pursuant to the applicable voting procedures of the NFL Constitution and Bylaws.\n",
+      "Any intra-League dispute or call for interpretation in connection with these rules will be decided by the Commissioner of the League, whose ruling will be final.\n",
+      "Because inter-conference games are played throughout the preseason, regular season, and postseason in  the  NFL, all  rules contained in  this  book apply uniformly to both the American and National Football Conferences.\n",
+      "Where the word 'illegal' appears in this rule book, it is an institutional term of art pertaining strictly to actions that violate NFL playing rules. It is not meant to connote illegality under any public law or the rules or regulations of any other organization.\n",
+      "The word 'flagrant,' when used here to describe an action by a player, is meant to indicate that the degree of a violation of the rules-usually a personal foul or  unnecessary roughness-is extremely objectionable, conspicuous, unnecessary, avoidable, or gratuitous. 'Flagrant' in these rules does not necessarily imply malice on the part of the fouling player or an intention to injure an opponent.\n",
+      "Copyright © 2022 by the National Football League. All rights reserved. Printed in the United States of America.\n",
+      "Bottom of the yard line numbers must be 12 yards from the sideline.\n",
+      "Selected 2 contexts\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:06<00:00,  3.47s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-nfl-rulebook-final: Status.SUCCESS\n",
+      "processing chunks that looks like:\n",
+      "Opening Deposit\n",
+      "$100 or more\n",
+      "Interest Rate\n",
+      "This account earns interest at a variable rate. You can find current rate information at bankofamerica.com, by calling the number on your account statement or visiting a financial center.\n",
+      "Monthly\n",
+      "Maintenance\n",
+      "Fee\n",
+      "$25.00 each month. You can avoid the Monthly Maintenance Fee when you meet ONE of the following requirements during each statement cycle:\n",
+      "• Maintain a minimum daily balance of $20,000 or more in your account OR\n",
+      "• Be a member of the Preferred Rewards program. Learn more at bankofamerica.com/preferred-rewards.\n",
+      "ATM fees\n",
+      "Bank of America ATMs\n",
+      "No ATM fee\n",
+      "For deposits, withdrawals, transfers or balance inquiries\n",
+      "Non-Bank of America ATMs\n",
+      "$2.50\n",
+      "In the U.S., plus any fee charged by the ATM's operator\n",
+      "$5.00\n",
+      "Outside the U.S., plus any fee charged by the ATM's operator\n",
+      "Selected 2 contexts\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:08<00:00,  4.06s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BofA_InterestChecking_en_ADA: Status.SUCCESS\n",
+      "processing chunks that looks like:\n",
+      "Large language models (LLMs) have achieved significant performance gains via scaling up model sizes and/or data. However, recent evidence suggests diminishing returns from such approaches, motivating scaling the computation spent at inference time. Existing inference-time scaling methods, usually with reward models, cast the task as a search problem, which tends to be vulnerable to reward hacking as a consequence of approximation errors in reward models. In this paper, we instead cast inference-time scaling as a probabilistic inference task and leverage sampling-based techniques to explore the typical set of the state distribution of a state-space model with an approximate likelihood, rather than optimize for its mode directly. We propose a novel inference-time scaling approach by adapting particle-based Monte Carlo methods to this task. Our empirical evaluation demonstrates that our methods have a 4-16x better scaling rate over our deterministic search counterparts on various challenging mathematical reasoning tasks. Using our approach, we show that Qwen2.5-Math-1.5B-Instruct can surpass GPT4o accuracy in only 4 rollouts, while Qwen2.5Math-7B-Instruct scales to o1 level accuracy in only 32 rollouts. Our work not only presents an effective method to inference-time scaling, but also connects the rich literature in probabilistic inference with inference-time scaling of LLMs to develop more robust algorithms in future work. Code, videos, and further information available at probabilistic-inference-scaling.github.io/ .\n",
+      "Selected 2 contexts\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:08<00:00,  4.08s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2502.01618v3: Status.SUCCESS\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "import random #TODO: replace random sampling with subset selection\n",
     "\n",
-    "for doc, chunks in dataset.items(): # TODO: multiple file support\n",
+    "generated_files = []\n",
+    "\n",
+    "for doc, chunks in dataset.items():\n",
     "    generate_options.generated_file = AUTHORING_OUTPUT_DIR / f\"qagen-{doc}.json\"\n",
     "    gen = Generator(generate_options=generate_options)\n",
     "    print(f\"processing chunks that looks like:\\n{chunks[0].text}\")\n",
-    "    selected_chunks = random.sample(chunks, NUM_CHUNKS_TO_SELECT_FOR_AUTHORING)\n",
+    "    selected_chunks = random.sample(chunks, NUM_CHUNKS_PER_FILE_TO_SELECT_FOR_AUTHORING)\n",
     "    print(f\"Selected {len(selected_chunks)} contexts\")\n",
     "\n",
     "    Path.unlink(generate_options.generated_file, missing_ok=True)\n",
     "    results = gen.generate_from_chunks(selected_chunks) # automatically saves to file\n",
+    "    generated_files.append(generate_options.generated_file)\n",
     "\n",
-    "    print(f\"{doc}: {results.status}\")\n",
-    "    break"
+    "    print(f\"{doc}: {results.status}\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "22b2513fbb180dd8",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -462,10 +618,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "id": "9df2c533-30d7-4c30-9907-7c5655fd2246",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated QA pairs for 13 contexts\n",
+      "[{'question': 'What is the mandatory color for the lower portion of game socks and/or leg coverings?', 'answer': 'White'}, {'question': \"What are the color options for a player's uniform, including helmets, jerseys, pants, and game socks and/or leg coverings?\", 'answer': 'Players are permitted to wear only the colors or a combination of those colors established for their NFL club in the League Constitution and Bylaws, with white also being an available color for jerseys and mandatory for the lower portion of game socks and/or leg coverings. Each player on a given team must wear the same colors on his uniform as all other players on his team in the same game.'}, {'question': 'Based on the policy, why is it important for players to present an appearance that is appropriate to representing their individual clubs and the National Football League?', 'answer': 'The policy emphasizes professionalism and representation, suggesting that the appearance of players reflects on both their individual clubs and the league as a whole. Therefore, maintaining an appropriate appearance is important for upholding the image and reputation of both the club and the league.'}]\n"
+     ]
+    }
+   ],
    "source": [
     "import json\n",
     "import yaml\n",
@@ -473,15 +638,16 @@
     "\n",
     "qnas = {}\n",
     "chunk_id_to_text = {}\n",
-    "with open(generate_options.generated_file, \"rt\") as f:\n",
-    "    for line in f.readlines():\n",
-    "        entry = json.loads(line)\n",
-    "        chunk_id = entry['chunk_id']\n",
-    "        if chunk_id not in chunk_id_to_text:\n",
-    "            chunk_id_to_text[chunk_id] = entry['context']\n",
-    "        if chunk_id not in qnas:\n",
-    "            qnas[chunk_id] = []\n",
-    "        qnas[chunk_id].append({'question': entry['question'], 'answer': entry['answer']})\n",
+    "for file in generated_files:\n",
+    "    with open(file, \"rt\") as f:\n",
+    "        for line in f.readlines():\n",
+    "            entry = json.loads(line)\n",
+    "            chunk_id = entry['chunk_id']\n",
+    "            if chunk_id not in chunk_id_to_text:\n",
+    "                chunk_id_to_text[chunk_id] = entry['context']\n",
+    "            if chunk_id not in qnas:\n",
+    "                qnas[chunk_id] = []\n",
+    "            qnas[chunk_id].append({'question': entry['question'], 'answer': entry['answer']})\n",
     "\n",
     "print(f\"Generated QA pairs for {len(qnas)} contexts\")\n",
     "print(list(qnas.values())[0])"
@@ -497,7 +663,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 54,
    "id": "c7130e90-2b65-4008-86f7-194da74a9523",
    "metadata": {},
    "outputs": [],
@@ -516,10 +682,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 63,
    "id": "d7f26460-737f-4940-b58a-ef6caea313d3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "qna.yaml saved to: workspaces/default/authoring/qna.yaml\n"
+     ]
+    }
+   ],
    "source": [
     "qna_output_path = AUTHORING_OUTPUT_DIR / \"qna.yaml\"\n",
     "\n",
@@ -575,10 +749,358 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 64,
    "id": "1293d445-b826-4b92-ad20-9b121ac60e20",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "seed_examples:\n",
+      "  - context: |-\n",
+      "      ARTICLE 1.  GENERAL POLICY. Throughout the game-day period while in view of the stadium and television audience, including during team pregame warm-ups, all players must dress in a professional manner under the uniform standards. The helmet and mandatory padding referenced in Article 3 below are intended to provide reasonable protection to a player while reasonably avoiding risk of injury to other players. The development of Playing Rules should be governed by this Article. Players generally must present an appearance that is appropriate to representing their individual clubs and the National Football League. The term uniform, as used in this policy, applies to every piece of equipment worn by a player, including helmet, shoulder pads, thigh pads, knee pads, and any other item of protective gear, and to every visible item of apparel, including but not limited to pants, jerseys, wristbands, gloves, game socks and/or leg coverings, shoes, visible undergarments, and accessories such as headwear worn under helmets and hand towels. All visible items worn on game day by players must be issued by the club or the League, or, if from outside sources, must have approval in advance by the League office.\n",
+      "      ARTICLE 2.  TEAM COLORS. Pursuant to the official colors established for each NFL club in the League Constitution and Bylaws, playing squads are permitted to wear only those colors or a combination of those colors for helmets, jerseys, pants, and game socks and/or leg coverings; provided that white is also an available color for jerseys and mandatory color for the lower portion of game socks and/or leg coverings. (See 5-4-3-Item 6, 'Game socks and/or leg coverings,' below). Each player on a given team must wear the same colors on his uniform as all other players on his team in the same game. Home clubs shall choose their jersey color (either white or official team color), and visiting clubs must wear the opposite. For preseason, regular season, or postseason\n",
+      "    questions_and_answers:\n",
+      "      - question: |-\n",
+      "          What is the mandatory color for the lower portion of game socks and/or leg\n",
+      "          coverings?\n",
+      "        answer: White\n",
+      "      - question: |-\n",
+      "          What are the color options for a player's uniform, including helmets, jerseys,\n",
+      "          pants, and game socks and/or leg coverings?\n",
+      "        answer: |-\n",
+      "          Players are permitted to wear only the colors or a combination of those colors\n",
+      "          established for their NFL club in the League Constitution and Bylaws, with white\n",
+      "          also being an available color for jerseys and mandatory for the lower portion of\n",
+      "          game socks and/or leg coverings. Each player on a given team must wear the same\n",
+      "          colors on his uniform as all other players on his team in the same game.\n",
+      "      - question: |-\n",
+      "          Based on the policy, why is it important for players to present an appearance\n",
+      "          that is appropriate to representing their individual clubs and the National\n",
+      "          Football League?\n",
+      "        answer: |-\n",
+      "          The policy emphasizes professionalism and representation, suggesting that the\n",
+      "          appearance of players reflects on both their individual clubs and the league as\n",
+      "          a whole. Therefore, maintaining an appropriate appearance is important for\n",
+      "          upholding the image and reputation of both the club and the league.\n",
+      "  - context: |-\n",
+      "      Third-and-5 on B40. End A2 is illegally chucked out of bounds at the B30, immediately returns inbounds, and is interfered with by B2 at the B25, while the pass is in the air. B2 intercepts the ball and is tackled at the B40.\n",
+      "      Ruling: A's ball, first-and-10 on B25. Since A2 was illegally contacted out of bounds, he is an eligible receiver as soon as he re-establishes, and this is defensive pass interference. Decline the illegal contact penalty. A2 must make an immediate attempt to return inbounds in order to be eligible.\n",
+      "    questions_and_answers:\n",
+      "      - question: What is the ruling of the play?\n",
+      "        answer: A's ball, first-and-10 on B25.\n",
+      "      - question: What are the key penalties and their outcomes in this play?\n",
+      "        answer: |-\n",
+      "          There are two penalties in this play: illegal contact and defensive pass\n",
+      "          interference. The illegal contact penalty is declined, and the defensive pass\n",
+      "          interference results in A's ball, first-and-10 on B25.\n",
+      "  - context: |-\n",
+      "      Fourth-and-3 on B20. On a field-goal attempt, center A5 lines up on the end of\n",
+      "      the line in the middle of the field. Holder A2 and kicker A1 line up directly\n",
+      "      behind A5. The rest of the team is lined up at the inbounds line 15 yards away\n",
+      "      from center A5. The ball is snapped by A5 to up-back A4, who is lined up behind\n",
+      "      the rest of the line at the inbounds spot. A5 did not snap the ball through his\n",
+      "      legs. A4 runs to the B5 where he is tackled. Center A5: (a) reported as eligible\n",
+      "      prior to the snap; or (b) A5 did not report as eligible prior to the snap.\n",
+      "    questions_and_answers:\n",
+      "      - question: Did center A5 report as eligible prior to the snap?\n",
+      "        answer: No, according to the passage, A5 did not report as eligible prior\n",
+      "          to the snap.\n",
+      "      - question: What is the formation of the team at the time of the snap?\n",
+      "        answer: |-\n",
+      "          At the time of the snap, center A5 is at the end of the line in the middle of\n",
+      "          the field, holder A2 and kicker A1 are directly behind A5, and the rest of the\n",
+      "          team is lined up at the inbounds line 15 yards away from center A5. The ball is\n",
+      "          snapped by A5 to up-back A4, who is lined up behind the rest of the line at the\n",
+      "          inbounds spot.\n",
+      "      - question: Based on the information provided, can we determine if this was\n",
+      "          a legal play?\n",
+      "        answer: |-\n",
+      "          No, the passage does not provide enough information to determine if this was a\n",
+      "          legal play. It only mentions that center A5 did not report as eligible prior to\n",
+      "          the snap, but it does not specify if this is a requirement for the play or if\n",
+      "          any rules were violated.\n",
+      "  - context: |-\n",
+      "      (a) B's ball, first-and-10 on B27. The kick ended behind the line of scrimmage, so there is no 'spot of kick' option.\n",
+      "      (b) B's ball, first-and-10 on B17. The kick ended behind the line of scrimmage, so there is no 'spot of kick' option. Since A2 legally advanced the untouched kick recovered behind the line, his advance is legal, and Team B takes over on downs at the dead ball spot.\n",
+      "      (c) A's ball, first-and-10 on B14. The kick ended behind the line of scrimmage, so there is no 'spot of kick' option. Since A2 legally advanced the untouched kick recovered behind the line, his advance is legal. A2 reached the line to gain, so it is a first down for Team A.\n",
+      "      (d) B's ball, first-and-10 on B30. Illegal forward pass, as the ball has been beyond the line. The penalty is five yards from the previous spot and a loss of down. The kick ended behind the line of scrimmage, so there is no 'spot of kick' option.\n",
+      "      (e) B's ball, first-and-10 on B31. The kick ended behind the line of scrimmage, so there is no 'spot of kick' option. Team B keeps the ball at the dead ball spot.\n",
+      "      Note : Team B does not have the option to take the ball at the spot of the kick if: (1) B touches the ball beyond the line of scrimmage; (2) the kick ends behind the line; or (3) a Team B foul during the play is accepted.\n",
+      "    questions_and_answers:\n",
+      "      - question: |-\n",
+      "          What happens if a team recovers an untouched kick behind the line of scrimmage\n",
+      "          and legally advances it?\n",
+      "        answer: |-\n",
+      "          The team that advanced the kick legally takes over on downs at the dead ball\n",
+      "          spot.\n",
+      "      - question: |-\n",
+      "          What are the conditions under which Team B cannot take the ball at the spot of\n",
+      "          the kick?\n",
+      "        answer: |-\n",
+      "          Team B cannot take the ball at the spot of the kick if B touches the ball beyond\n",
+      "          the line of scrimmage, the kick ends behind the line, or a Team B foul during\n",
+      "          the play is accepted.\n",
+      "      - question: |-\n",
+      "          If Team B commits an illegal forward pass beyond the line of scrimmage, what is\n",
+      "          the penalty?\n",
+      "        answer: The penalty is five yards from the previous spot and a loss of down.\n",
+      "  - context: |-\n",
+      "      Second-and-10 on A20. A2 takes a handoff and runs to the 50. As he is being\n",
+      "      tackled, he hands the ball to A3 who is running parallel with him. A3 initially\n",
+      "      touches the ball at the 50, but doesn't control it until the B48 ahead of A2. A3\n",
+      "      runs for a touchdown. Ruling: Reviewable. Legal handoff, touchdown. For it to be\n",
+      "      illegal, the player receiving the handoff must be clearly in advance of the\n",
+      "      player making the handoff when he first touches the ball. Only the Replay\n",
+      "      Official can initiate a review of this play.\n",
+      "    questions_and_answers:\n",
+      "      - question: Who can initiate a review of the play?\n",
+      "        answer: Only the Replay Official can initiate a review of this play.\n",
+      "      - question: What was the outcome of the play and what was the ruling on its\n",
+      "          legality?\n",
+      "        answer: |-\n",
+      "          A3 ran for a touchdown and the ruling was that it was a legal handoff and\n",
+      "          touchdown.\n",
+      "      - question: |-\n",
+      "          Based on the information provided, was A3 in advance of A2 when he first touched\n",
+      "          the ball?\n",
+      "        answer: |-\n",
+      "          No, A3 initially touched the ball at the 50, but didn't control it until the B48\n",
+      "          ahead of A2.\n",
+      "  - context: \"\\xB7 Cash, direct deposits, wire transfers: On the day we receive them.\\n\\\n",
+      "      \\xB7 Checks: Usually the next business day, if deposited before the financial\\\n",
+      "      \\ center or ATM cutoff time.\\n\\xB7 Mobile Check Deposit: Usually the next business\\\n",
+      "      \\ day if deposited by applicable cutoff times. Please refer to Deposit Checks\\\n",
+      "      \\ , then Help in the Mobile Banking app for additional details and terms and\\\n",
+      "      \\ conditions.\\n\\xB7 If we place a hold on your deposit, we'll let you know the\\\n",
+      "      \\ hold reason and when your funds will be available. This is typically provided\\\n",
+      "      \\ at the time of deposit but may also be mailed later. Deposits greater than\\\n",
+      "      \\ $5,525 and checks deposited within the first 30 days of account opening may\\\n",
+      "      \\ be held longer.\"\n",
+      "    questions_and_answers:\n",
+      "      - question: What is the usual availability of cash and wire transfers when received?\n",
+      "        answer: On the day they are received.\n",
+      "      - question: What is the usual availability of funds for different types of deposits?\n",
+      "        answer: |-\n",
+      "          Direct deposits and wire transfers are usually available on the day they are\n",
+      "          received, checks are usually available the next business day if deposited before\n",
+      "          the cutoff time, and mobile check deposits are usually available the next\n",
+      "          business day if deposited by applicable cutoff times.\n",
+      "      - question: If a deposit is held, when are the funds typically available?\n",
+      "        answer: |-\n",
+      "          If a deposit is held, the funds will typically be available when the hold is\n",
+      "          released, which is typically communicated at the time of deposit but may also be\n",
+      "          mailed later. Deposits greater than $5,525 and checks deposited within the first\n",
+      "          30 days of account opening may be held longer.\n",
+      "  - context: \"Opening Deposit\\n$100 or more\\nInterest Rate\\nThis account earns interest\\\n",
+      "      \\ at a variable rate. You can find current rate information at bankofamerica.com,\\\n",
+      "      \\ by calling the number on your account statement or visiting a financial center.\\n\\\n",
+      "      Monthly\\nMaintenance\\nFee\\n$25.00 each month. You can avoid the Monthly Maintenance\\\n",
+      "      \\ Fee when you meet ONE of the following requirements during each statement\\\n",
+      "      \\ cycle:\\n\\u2022 Maintain a minimum daily balance of $20,000 or more in your\\\n",
+      "      \\ account OR\\n\\u2022 Be a member of the Preferred Rewards program. Learn more\\\n",
+      "      \\ at bankofamerica.com/preferred-rewards.\\nATM fees\\nBank of America ATMs\\n\\\n",
+      "      No ATM fee\\nFor deposits, withdrawals, transfers or balance inquiries\\nNon-Bank\\\n",
+      "      \\ of America ATMs\\n$2.50\\nIn the U.S., plus any fee charged by the ATM's operator\\n\\\n",
+      "      $5.00\\nOutside the U.S., plus any fee charged by the ATM's operator\"\n",
+      "    questions_and_answers:\n",
+      "      - question: What is the variable interest rate for this account?\n",
+      "        answer: |-\n",
+      "          The text does not provide the variable interest rate for this account. It can be\n",
+      "          found at bankofamerica.com, by calling the number on your account statement or\n",
+      "          visiting a financial center.\n",
+      "      - question: What are the ways to avoid the monthly maintenance fee of $25?\n",
+      "        answer: |-\n",
+      "          The monthly maintenance fee of $25 can be avoided by maintaining a minimum daily\n",
+      "          balance of $20,000 or more in the account or by being a member of the Preferred\n",
+      "          Rewards program.\n",
+      "      - question: |-\n",
+      "          If I have a balance of $20,000 in my account, will I still be charged the ATM\n",
+      "          fee for using a non-Bank of America ATM?\n",
+      "        answer: |-\n",
+      "          No, if you maintain a minimum daily balance of $20,000 or more in your account,\n",
+      "          you will not be charged the ATM fee for using a non-Bank of America ATM.\n",
+      "          However, you may still be charged a fee by the ATM's operator.\n",
+      "  - context: \"\\xB7 To help you avoid fees, we won't authorize ATM withdrawals or everyday\\\n",
+      "      \\ debit card purchases when you don't have enough money in your account at the\\\n",
+      "      \\ time of the transaction.\\n\\xB7 When we determine you don't have enough money\\\n",
+      "      \\ in your account to cover other items such as checks or scheduled payments,\\\n",
+      "      \\ we'll either authorize and pay the item and overdraw your account (an overdraft\\\n",
+      "      \\ item),  or decline or return the item unpaid (a returned item). When 1 this\\\n",
+      "      \\ happens, you may be charged a fee. See details below.\\n\\u2022 We offer two\\\n",
+      "      \\ overdraft setting options for how you want us to process your other transactions.\"\n",
+      "    questions_and_answers:\n",
+      "      - question: |-\n",
+      "          What happens when there is not enough money in the account to cover other items\n",
+      "          like checks or scheduled payments?\n",
+      "        answer: |-\n",
+      "          The bank will either authorize and pay the item and overdraw the account, or\n",
+      "          decline or return the item unpaid.\n",
+      "      - question: |-\n",
+      "          What are the two overdraft setting options the bank offers for processing other\n",
+      "          transactions?\n",
+      "        answer: The bank offers two overdraft setting options for processing other\n",
+      "          transactions.\n",
+      "      - question: |-\n",
+      "          If the bank overdraws an account and charges a fee, why might a customer\n",
+      "          consider changing their overdraft setting option?\n",
+      "        answer: |-\n",
+      "          A customer might consider changing their overdraft setting option to avoid or\n",
+      "          reduce the frequency of overdraft fees.\n",
+      "  - context: \"Review all the features and benefits of your new account at bankofamerica.com/quickstart\\n\\\n",
+      "      For questions, schedule an appointment to visit a financial center at bankofamerica.com/appointments\\n\\\n",
+      "      Call us at 800.432.1000\\nAdditional fee waivers may be available to Bank of\\\n",
+      "      \\ America Private Bank and qualified Merrill Lynch Wealth Management \\xAE clients.\\\n",
+      "      \\ Please contact your advisor to learn more. Merrill Lynch, Pierce, Fenner &\\\n",
+      "      \\ Smith Incorporated (also referred to as 'MLPF&S' or 'Merrill') makes available\\\n",
+      "      \\ certain investment products sponsored, managed, distributed or provided by\\\n",
+      "      \\ companies that are affiliates of Bank of America Corporation ('BofA Corp.').\\\n",
+      "      \\ MLPF&S is a registered broker-dealer, registered investment advisor, Member\\\n",
+      "      \\ SIPC and a wholly owned subsidiary of BofA Corp.\\nInvestment products:\\nAre\\\n",
+      "      \\ Not FDIC Insured\\nAre Not Bank Guaranteed\\nMay Lose Value\\nBanking products\\\n",
+      "      \\ are provided by Bank of America, N.A. and affiliated banks, Members FDIC and\\\n",
+      "      \\ wholly owned subsidiaries of Bank of America Corporation.\"\n",
+      "    questions_and_answers:\n",
+      "      - question: What is the phone number to contact Bank of America?\n",
+      "        answer: 800.432.1000\n",
+      "      - question: What services does Bank of America offer through its website?\n",
+      "        answer: |-\n",
+      "          Bank of America offers account review, fee waiver inquiries, appointment\n",
+      "          scheduling, and customer service through its website.\n",
+      "      - question: |-\n",
+      "          If a Bank of America Private Bank or Merrill Lynch Wealth Management client\n",
+      "          contacts their advisor regarding additional fee waivers, what would be the\n",
+      "          outcome?\n",
+      "        answer: The client would learn more about any available fee waivers.\n",
+      "  - context: |-\n",
+      "      Additional fees, 1 = Additional fees. Additional fees, 2 = Additional fees.\n",
+      "      Statement copies, 1 = No fee. Statement copies, 2 = Paper copies available upon\n",
+      "      request. Printable statements are available in Online Banking.. Check images, 1\n",
+      "      = No fee. Check images, 2 = Printable check images from the last 18 months are\n",
+      "      available online.. Ordering checks, 1 = Varies. Ordering checks, 2 = No fee on\n",
+      "      standard styles and discounts on certain styles. Card replacement, 1 = No fee.\n",
+      "      Card replacement, 2 = For each ATM or debit card. Card replacement, 1 = $15.00.\n",
+      "      Card replacement, 2 = For rush delivery. Stop payment, 1 = WAIVED $30.00. Stop\n",
+      "      payment, 2 = For each request. Cashier's checks, 1 = $15.00. Cashier's checks, 2\n",
+      "      = For each check. Domestic wire transfers, 1 = WAIVED $15.00. Domestic wire\n",
+      "      transfers, 2 = For each incoming wire transfer. Domestic wire transfers, 1 =\n",
+      "      $30.00. Domestic wire transfers, 2 = For each outgoing wire transfer.\n",
+      "      International wire transfers, 1 = $15.00. International wire transfers, 2 = For\n",
+      "      each incoming wire transfer: If received in a foreign currency, it will be\n",
+      "      converted into U.S. Dollars using the applicable exchange rate determined solely\n",
+      "      by us.. International wire transfers, 1 = No wire fee. International wire\n",
+      "      transfers, 2 = For each outgoing wire transfer sent in foreign currency. Please\n",
+      "      be advised, exchange rate markups will apply. See below.. International wire\n",
+      "      transfers, 1 = $45.00. International wire transfers, 2 = For each outgoing wire\n",
+      "      transfer sent in U.S. Dollars. For international wire transfers, other fees may\n",
+      "      also apply, including those charged by recipient's financial institution,\n",
+      "      foreign taxes, and other fees that are part of the wire transfer process. We\n",
+      "      profit from markups associated with the currency conversion included in our\n",
+      "      exchange rate (determined solely by us). Before sending in foreign currency, you\n",
+      "      should consider factors that impact the total cost or the amount available after\n",
+      "      transfer., 1 = For international wire transfers, other fees may also apply,\n",
+      "      including those charged by recipient's financial institution, foreign taxes, and\n",
+      "      other fees that are part of the wire transfer process. We profit from markups\n",
+      "      associated with the currency conversion included in our exchange rate\n",
+      "      (determined solely by us). Before sending in foreign currency, you should\n",
+      "      consider factors that impact the total cost or\n",
+      "    questions_and_answers:\n",
+      "      - question: What is the fee for ordering checks with standard styles?\n",
+      "        answer: No fee\n",
+      "      - question: What are the fees associated with international wire transfers?\n",
+      "        answer: |-\n",
+      "          For incoming wire transfers in foreign currency, there is a $15 fee and a\n",
+      "          currency conversion markup. For incoming wire transfers in US dollars, there is\n",
+      "          a $45 fee. For outgoing wire transfers in foreign currency, there is a $15 fee\n",
+      "          and a currency conversion markup. For outgoing wire transfers in US dollars,\n",
+      "          there is a $30 fee. Other fees may also apply, including those charged by the\n",
+      "          recipient's financial institution, foreign taxes, and other fees that are part\n",
+      "          of the wire transfer process.\n",
+      "      - question: |-\n",
+      "          Considering the information about international wire transfers, why might it be\n",
+      "          more cost-effective to send a wire transfer in a foreign currency rather than in\n",
+      "          US dollars?\n",
+      "        answer: |-\n",
+      "          Sending a wire transfer in a foreign currency might be more cost-effective\n",
+      "          because, even though there is a currency conversion markup, the fee for incoming\n",
+      "          wire transfers in foreign currency is lower than the fee for incoming wire\n",
+      "          transfers in US dollars. However, other factors such as fees charged by the\n",
+      "          recipient's financial institution, foreign taxes, and other fees that are part\n",
+      "          of the wire transfer process should also be considered.\n",
+      "  - context: |-\n",
+      "      Closed-Source LLMs, Method = . Closed-Source LLMs, MATH500 = . Closed-Source\n",
+      "      LLMs, AIME 2024 = . GPT-4o, Method = -. GPT-4o, MATH500 = 76.2. GPT-4o, AIME\n",
+      "      2024 = 13.3. o1-preview, Method = -. o1-preview, MATH500 = 87.0. o1-preview,\n",
+      "      AIME 2024 = 40.0. Claude3.5-Sonnet, Method = -. Claude3.5-Sonnet, MATH500 =\n",
+      "      78.3. Claude3.5-Sonnet, AIME 2024 = 16.0. Open-Source LLMs, Method = . Open-\n",
+      "      Source LLMs, MATH500 = . Open-Source LLMs, AIME 2024 = . Llama-3.1-70B-Instruct,\n",
+      "      Method = -. Llama-3.1-70B-Instruct, MATH500 = 65.7. Llama-3.1-70B-Instruct, AIME\n",
+      "      2024 = 16.6. Qwen2.5-Math-72B-Instruct, Method = -. Qwen2.5-Math-72B-Instruct,\n",
+      "      MATH500 = 82.0. Qwen2.5-Math-72B-Instruct, AIME 2024 = 30.0. Open-Source SLMs,\n",
+      "      Method = . Open-Source SLMs, MATH500 = . Open-Source SLMs, AIME 2024 = .\n",
+      "      Llama-3.2-1B-Instruct, Method = Pass@1. Llama-3.2-1B-Instruct, MATH500 = 26.8.\n",
+      "      Llama-3.2-1B-Instruct, AIME 2024 = 0.0. , Method = BoN. , MATH500 = 46.6. , AIME\n",
+      "      2024 = 3.3. , Method = WBoN. , MATH500 = 47.8. , AIME 2024 = 3.3. , Method =\n",
+      "      DVTS. , MATH500 = 52.8. , AIME 2024 = 6.6. , Method = Ours - PF. , MATH500 =\n",
+      "      59.6. , AIME 2024 = 10.0. Llama-3.1-8B-Instruct, Method = Pass@1.\n",
+      "    questions_and_answers:\n",
+      "      - question: What is the MATH500 score for GPT-4o?\n",
+      "        answer: '76.2'\n",
+      "      - question: |-\n",
+      "          Which models have a higher AIME 2024 score: GPT-4o, o1-preview,\n",
+      "          Claude3.5-Sonnet, Llama-3.1-70B-Instruct, Qwen2.5-Math-72B-Instruct, or\n",
+      "          Llama-3.2-1B-Instruct?\n",
+      "        answer: |-\n",
+      "          Qwen2.5-Math-72B-Instruct has the highest AIME 2024 score among the mentioned\n",
+      "          models.\n",
+      "  - context: |-\n",
+      "      Lightman, H., Kosaraju, V., Burda, Y., Edwards, H., Baker, B., Lee, T., Leike, J., Schulman, J., Sutskever, I., and Cobbe, K. Let's verify step by step, 2023b. URL https: //arxiv.org/abs/2305.20050 .\n",
+      "      Loula, J., LeBrun, B., Du, L., Lipkin, B., Pasti, C., Grand, G., Liu, T., Emara, Y., Freedman, M., Eisner, J., Cotterell, R., Mansinghka, V., Lew, A. K., Vieira, T., and O'Donnell, T. J. Syntactic and semantic control of large language models via sequential monte carlo. In The Thirteenth International Conference on Learning Representations , 2025. URL https://openreview.net/ forum?id=xoXn62FzD0 .\n",
+      "      MacKay, D. J. Information theory, inference and learning algorithms . Cambridge university press, 2003.\n",
+      "      Moral, P. D. Sequential Monte Carlo Methods for Dynamic Systems: Journal of the American Statistical Association: Vol 93, No 443. https://www.tandfonline.com/doi/abs/10.1080/01621459.1998.10473765, 1997.\n",
+      "      Murphy, K. P. Machine learning: a probabilistic perspective . MIT press, 2012.\n",
+      "    questions_and_answers:\n",
+      "      - question: |-\n",
+      "          Who is one of the authors of the paper 'Syntactic and semantic control of large\n",
+      "          language models via sequential monte carlo'?\n",
+      "        answer: Loula, J.\n",
+      "      - question: |-\n",
+      "          If a language model is trained on a large corpus of text, could it be said to\n",
+      "          have 'learned' the statistics of the language? Why or why not?\n",
+      "        answer: |-\n",
+      "          Yes, according to the probabilistic perspective of machine learning, a language\n",
+      "          model can be seen as having 'learned' the statistics of the language, as it\n",
+      "          learns the probability distribution of the next word given the previous words.\n",
+      "          This is evident in the 'Machine learning: a probabilistic perspective' book by\n",
+      "          Kevin P. Murphy.\n",
+      "  - context: |-\n",
+      "      3. We study ways to use PRMs and propose a more robust and performant way to obtain rewards for partial answers which we refer to as model-based aggregation.\n",
+      "      4. We demonstrate that the proposed methods have 416x faster scaling speed than previous methods based on a search formulation on the MATH500 and AIME 2024 datasets, with small language models in the Llama and Qwen families. We show that PF can scale Qwen2.5-Math-1.5B-Instruct to surpasses GPT-4o accuracy with only a budget of 4 and scale Qwen2.5Math-7B-Instruct to o1 accuracy with a budget of 32.\n",
+      "    questions_and_answers:\n",
+      "      - question: |-\n",
+      "          How many times faster is the scaling speed of the proposed methods compared to\n",
+      "          previous methods?\n",
+      "        answer: 416x\n",
+      "      - question: |-\n",
+      "          What are the two datasets used to demonstrate the performance of the proposed\n",
+      "          methods and what are the two families of language models used?\n",
+      "        answer: |-\n",
+      "          The two datasets used are MATH500 and AIME 2024, and the two families of\n",
+      "          language models used are Llama and Qwen.\n",
+      "      - question: |-\n",
+      "          Based on the provided context, if you were to scale Qwen2.5-Math-1.5B-Instruct\n",
+      "          to surpass GPT-4's accuracy with the lowest possible budget, what would that\n",
+      "          budget be?\n",
+      "        answer: The budget would be 4.\n",
+      "document_outline: |-\n",
+      "  A Probabilistic Inference Approach to Inference-Time Scaling of LLMs using\n",
+      "  Particle-Based Monte Carlo Methods\n",
+      "domain: artificial intelligence\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "with open(qna_output_path) as yaml_file:\n",
     "    print(yaml_file.read())"
@@ -601,49 +1123,575 @@
    "source": [
     "## Create Seed Dataset for SDG\n",
     "\n",
-    "This notebook combines the contents from the qna.yaml and the chunks from the source document to create a seed dataset for the synthetic data generation process.\n",
+    "This section combines the contents from the qna.yaml and the chunks from the source document to create a seed dataset for the synthetic data generation process.\n",
     "\n",
-    "To run this notebook you need a directory that contains N chunks named `{original-file-name}-{N}.txt` and a `qna.yaml` in the same directory.\n",
+    "To run this step you need a directory that contains `chunks.jsonl` and a `qna.yaml` in the same directory.\n",
     "\n",
-    "This notebook outputs a `seed.jsonl` file in the `output_dir` that you set."
+    "This step outputs a seed.jsonl file in the SDG_OUTPUT_DIR that you set."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 65,
    "id": "e2c6e31b-e8a9-406c-b2dc-27433c8fd8ec",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
+     ]
+    }
+   ],
    "source": [
     "!pip install -qq datasets transformers"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 67,
    "id": "ab2c9ed2-8ba8-4959-8e01-81625b81d286",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "31028b6a6e894b55bdd91b429008b591",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "412be6db8f3b4d259bdd6ed8f9314bbd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "54e7f91dc8454798bfc61d605a62703a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "388343b9ee474bccb65cdb92b016d4fd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "33638125f9bb48f39a92e66b80d244bf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7fd66034f06d408a897b5d494f2f67c8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "922a16c14b1f4079963e90924419b301",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8bc2d4695b7146dc9595ce1a595930d7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c2222bfef0734126939deb3b9811f227",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f946dae206564cf985ca682f8c76b103",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1798 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "de809767e5754a87aacf4d12211d2086",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/17980 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c35f364424c54c5b97b0086c0c8a358f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Filter:   0%|          | 0/17980 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "18f604fd38eb4212ab3679be71c15ebe",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d8461ee8d54e456b83365ef02bb3d1a6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fcc7688505864e59ac9cb62a6606811b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c2ac4b36c760468c9d56816befa89ee3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "66c9085ac2ae4ca2b9ed499230d3a520",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8aa1805692424d138c6b4e31f3c0b9bc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6ae5908940d54fa8a7ffd79080e14057",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "01f80bb4ddec41da9ba2377f0ca724a0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "615184103ca2452b844bdd7058cf74d1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "46bd1643e1dc42cbbceb1e40782bec73",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "18813affd53f4f44961bacea83d577ad",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/100 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "709446274b054d488d824f061f451d64",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Filter:   0%|          | 0/100 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0dffa1a44904499198816aea085755c0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f2a538c0f64240faab131dc0bffdaf23",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7c9fb179536c483ca346aed2b7d06048",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "efe4f3e4db40492b8107ca012d2170b6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f2244a016bfb4e93bd625894b88e91ae",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1c109b96f4414670b1427761182f1faa",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8f6da7ff38f045419dc6213f6f1ff2ce",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "309b9ffca00f4371b015dad9757f9005",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "287e2af7ed854ac1bbdbd828f1a3fd87",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e76e59d35c194112a695449960a7a227",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/52 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2b2917e685e54e42a1df162c4d26bb4d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/520 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "11c2b9cf31304be0a78bb83ccef412f7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Filter:   0%|          | 0/520 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dedfc205063a4f748d2f003d549db666",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Creating json from Arrow format:   0%|          | 0/17 [00:00<?, ?ba/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Seed data contains 18600 rows\n",
+      "Results saved to: workspaces/default/sdg/seed_data.jsonl\n"
+     ]
+    }
+   ],
    "source": [
-    "import os\n",
-    "import shutil\n",
-    "\n",
     "from utils.create_seed_dataset import get_seed_dataset\n",
     "\n",
-    "src_files = os.listdir(CHUNKING_OUTPUT_DIR)\n",
-    "\n",
-    "for file_name in src_files:\n",
-    "    full_file_name = os.path.join(CHUNKING_OUTPUT_DIR, file_name)\n",
-    "    if os.path.isfile(full_file_name):\n",
-    "        shutil.copy(full_file_name, SEED_EXAMPLE_INPUT_DIR)\n",
-    "\n",
-    "shutil.copy(qna_output_path, SEED_EXAMPLE_INPUT_DIR)\n",
-    "\n",
-    "seed_data = get_seed_dataset(CHUNKING_OUTPUT_DIR, SEED_EXAMPLE_INPUT_DIR)\n",
+    "seed_data = get_seed_dataset(CHUNKING_OUTPUT_DIR, AUTHORING_OUTPUT_DIR)\n",
     "output_path = f'{SDG_OUTPUT_DIR}/seed_data.jsonl'\n",
     "seed_data.to_json(output_path, orient='records', lines=True)\n",
     "\n",
-    "print(f\"Generated {seed_data.data.num_rows} rows\")\n",
+    "print(f\"Seed data contains {seed_data.data.num_rows} rows\")\n",
     "print(f\"Results saved to: {output_path}\")"
    ]
   },
@@ -652,15 +1700,59 @@
    "id": "50ff36f4-19fc-4a27-b51a-3688e7b630e4",
    "metadata": {},
    "source": [
-    "### Inspect the generated data"
+    "### Inspect the seed data"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 68,
    "id": "a6936825-31c1-4b46-a1af-2fb46f50158d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pyarrow.Table\n",
+      "document_outline: string\n",
+      "document_title: string\n",
+      "domain: string\n",
+      "icl_document: string\n",
+      "icl_query_1: string\n",
+      "icl_response_1: string\n",
+      "icl_query_2: string\n",
+      "icl_response_2: string\n",
+      "icl_query_3: string\n",
+      "icl_response_3: string\n",
+      "document: string\n",
+      "----\n",
+      "document_outline: [[\"A Probabilistic Inference Approach to Inference-Time Scaling of LLMs using\n",
+      "Particle-Based Monte Carlo Methods\"]]\n",
+      "document_title: [[\"2022-nfl-rulebook-final\"]]\n",
+      "domain: [[\"artificial intelligence\"]]\n",
+      "icl_document: [[\"ARTICLE 1.  GENERAL POLICY. Throughout the game-day period while in view of the stadium and television audience, including during team pregame warm-ups, all players must dress in a professional manner under the uniform standards. The helmet and mandatory padding referenced in Article 3 below are intended to provide reasonable protection to a player while reasonably avoiding risk of injury to other players. The development of Playing Rules should be governed by this Article. Players generally must present an appearance that is appropriate to representing their individual clubs and the National Football League. The term uniform, as used in this policy, applies to every piece of equipment worn by a player, including helmet, shoulder pads, thigh pads, knee pads, and any other item of protective gear, and to every visible item of apparel, including but not limited to pants, jerseys, wristbands, gloves, game socks and/or leg coverings, shoes, visible undergarments, and accessories such as headwear worn under helmets and hand towels. All visible items worn on game day by players must be issued by the club or the League, or, if from outside sources, must have approval in advance by the League office.\n",
+      "ARTICLE 2.  TEAM COLORS. Pursuant to the official colors established for each NFL club in the League Constitution and Bylaws, playing squads are permitted to wear only those colors or a combination of those colors for helmets, jerseys, pants, and game socks and/or leg coverings; provided that white is also an available color for jerseys and mandatory color for the lower portion of game socks and/or leg coverings. (See 5-4-3-Item 6, 'Game socks and/or leg coverings,' below). Each player on a given team must wear the same colors on his uniform as all other players on his team in the same game. Home clubs shall choose their jersey color (either white or official team color), and visiting clubs must wear the opposite. For preseason, regular season, or postseason\"]]\n",
+      "icl_query_1: [[\"What is the mandatory color for the lower portion of game socks and/or leg\n",
+      "coverings?\"]]\n",
+      "icl_response_1: [[\"White\"]]\n",
+      "icl_query_2: [[\"What are the color options for a player's uniform, including helmets, jerseys,\n",
+      "pants, and game socks and/or leg coverings?\"]]\n",
+      "icl_response_2: [[\"Players are permitted to wear only the colors or a combination of those colors\n",
+      "established for their NFL club in the League Constitution and Bylaws, with white\n",
+      "also being an available color for jerseys and mandatory for the lower portion of\n",
+      "game socks and/or leg coverings. Each player on a given team must wear the same\n",
+      "colors on his uniform as all other players on his team in the same game.\"]]\n",
+      "icl_query_3: [[\"Based on the policy, why is it important for players to present an appearance\n",
+      "that is appropriate to representing their individual clubs and the National\n",
+      "Football League?\"]]\n",
+      "icl_response_3: [[\"The policy emphasizes professionalism and representation, suggesting that the\n",
+      "appearance of players reflects on both their individual clubs and the league as\n",
+      "a whole. Therefore, maintaining an appropriate appearance is important for\n",
+      "upholding the image and reputation of both the club and the league.\"]]\n",
+      "...\n"
+     ]
+    }
+   ],
    "source": [
     "print(seed_data.data.table.slice(length=1))"
    ]

--- a/notebooks/instructlab-knowledge/utils/create_seed_dataset.py
+++ b/notebooks/instructlab-knowledge/utils/create_seed_dataset.py
@@ -1,4 +1,4 @@
-i# Standard
+# Standard
 from pathlib import Path
 import json
 import re


### PR DESCRIPTION
`instructlab-knowledge.ipynb` only accepted one PDF file and created one `qna.yaml` file. This PR allows multiple .pdf files to be converted and chunked and allows multiple knowledge contributions each of which can have multiple source pdf files and have one qna.yaml generated.

This PR also contains minor cleanup also a changing to chunking code from having chunks in individual .txt files to all of the chunks being moved into a JSONL file.